### PR TITLE
Add a filter toggle to the Recent page

### DIFF
--- a/clowd_ui/Clowd.Ui/Controls/CollapsingSegmentedBar.axaml
+++ b/clowd_ui/Clowd.Ui/Controls/CollapsingSegmentedBar.axaml
@@ -1,0 +1,105 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="using:Clowd.UI.Controls">
+
+    <!-- The bar adds this file to its own Styles collection, so everything here is scoped to the
+         bar and its children — a caller usually hosts the bar outside its own styles (the Recent
+         page's filter lives in the window's page header), which is why the chrome travels with the
+         control rather than with the page that declares the segments. -->
+    <Styles.Resources>
+
+        <!-- One joined pill: the segments touch, so only the outer corners are rounded (the bar puts
+             the first/last classes on them) and only the first segment draws a left border — every
+             other one lets its neighbour's right border be the divider, which is what keeps the
+             seam 1px rather than 2. Accent-filled while active.
+
+             Templated rather than styled on top of Semi's ToggleButton so the resting / hover /
+             checked backgrounds are settled by this one Background property instead of by whichever
+             of the two themes wins. -->
+        <ControlTheme x:Key="ClowdSegmentedItem" TargetType="ToggleButton">
+            <Setter Property="Padding" Value="12,5" />
+            <Setter Property="MinWidth" Value="0" />
+            <Setter Property="MinHeight" Value="0" />
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+            <!-- the resting / hover fills the window's own buttons (New Editor, Screen Capture) use,
+                 so an inactive segment reads as a button rather than as a label in a box. -->
+            <Setter Property="Background" Value="{DynamicResource ButtonDefaultBackground}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource SemiColorBorder}" />
+            <Setter Property="BorderThickness" Value="0,1,1,1" />
+            <Setter Property="CornerRadius" Value="0" />
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding CornerRadius}"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          HorizontalAlignment="Center"
+                                          VerticalAlignment="Center" />
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^.first">
+                <Setter Property="BorderThickness" Value="1" />
+                <Setter Property="CornerRadius" Value="12,0,0,12" />
+            </Style>
+            <Style Selector="^.last">
+                <Setter Property="CornerRadius" Value="0,12,12,0" />
+            </Style>
+            <!-- a strip of one is both ends at once, and CornerRadius can only be set by one of the
+                 two styles above — so it says the whole thing here. -->
+            <Style Selector="^.first.last">
+                <Setter Property="CornerRadius" Value="12" />
+            </Style>
+            <Style Selector="^:pointerover">
+                <Setter Property="Background" Value="{DynamicResource ButtonDefaultPointeroverBackground}" />
+            </Style>
+            <Style Selector="^:checked">
+                <Setter Property="Background" Value="{DynamicResource SemiColorPrimary}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource SemiColorPrimary}" />
+                <Setter Property="Foreground" Value="{DynamicResource SemiColorWhite}" />
+            </Style>
+        </ControlTheme>
+
+        <!-- The collapsed strip: one pill wearing the resting segment chrome, carrying the selected
+             label and a chevron. Never drawn in the checked colours — it stands for the whole
+             strip, not for the option that happens to be active. -->
+        <ControlTheme x:Key="ClowdSegmentedDropDown" TargetType="Button">
+            <Setter Property="Padding" Value="12,5" />
+            <Setter Property="MinWidth" Value="0" />
+            <Setter Property="MinHeight" Value="0" />
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+            <Setter Property="Background" Value="{DynamicResource ButtonDefaultBackground}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource SemiColorBorder}" />
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="1"
+                            CornerRadius="12"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          HorizontalAlignment="Center"
+                                          VerticalAlignment="Center" />
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover">
+                <Setter Property="Background" Value="{DynamicResource ButtonDefaultPointeroverBackground}" />
+            </Style>
+        </ControlTheme>
+
+    </Styles.Resources>
+
+    <Style Selector="controls|CollapsingSegmentedBar > ToggleButton">
+        <Setter Property="Theme" Value="{StaticResource ClowdSegmentedItem}" />
+    </Style>
+
+    <Style Selector="controls|CollapsingSegmentedBar > Button">
+        <Setter Property="Theme" Value="{StaticResource ClowdSegmentedDropDown}" />
+    </Style>
+
+</Styles>

--- a/clowd_ui/Clowd.Ui/Controls/CollapsingSegmentedBar.cs
+++ b/clowd_ui/Clowd.Ui/Controls/CollapsingSegmentedBar.cs
@@ -1,0 +1,428 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using Avalonia;
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Shapes;
+using Avalonia.Data;
+using Avalonia.Layout;
+using Avalonia.Markup.Xaml.Styling;
+using Avalonia.Media;
+
+namespace Clowd.UI.Controls
+{
+    /// <summary>
+    /// A strip of mutually exclusive segments — one ToggleButton per option, each tagged with the
+    /// value it stands for — that collapses into a single dropdown when the space it is given cannot
+    /// hold them side by side. The dropdown is labelled with the option currently selected and its
+    /// menu offers the same choices, so a caller declares its segments once and the collapsed
+    /// presentation follows.
+    /// </summary>
+    /// <remarks>
+    /// Written from <see cref="CollapsingButtonBar"/>'s playbook, and the reasons it gives apply here
+    /// too: the collapse decision is taken in arrange as well as measure (a host that measures with
+    /// an infinite width — a Grid Auto column — only settles the real width once the row has been
+    /// arranged), and collapsed segments keep their place in the tree, because they are what the menu
+    /// is generated from. They are hidden with opacity rather than IsVisible, which belongs to the
+    /// caller.
+    ///
+    /// Where this one differs: it is single-select, so the collapsed state has to say *which* option
+    /// is active and cannot be that bar's anonymous ⋮ button; and its segments carry text rather than
+    /// icons, so it brings its own chrome (Controls/CollapsingSegmentedBar.axaml) instead of taking
+    /// style classes from the caller — the usual host is the window's page header, outside the styles
+    /// of the page the segments belong to.
+    ///
+    /// Note that the dropdown is itself Children[0] — the segments are declared after it — so index
+    /// into Children by identity, not position.
+    /// </remarks>
+    public class CollapsingSegmentedBar : Panel
+    {
+        public static readonly StyledProperty<double> SpacingProperty =
+            AvaloniaProperty.Register<CollapsingSegmentedBar, double>(nameof(Spacing), 1d);
+
+        /// <summary>Gap between the segments when they are shown side by side. A hairline by default:
+        /// the segments are drawn as one joined strip, so anything more would break the pill up.</summary>
+        public double Spacing
+        {
+            get => GetValue(SpacingProperty);
+            set => SetValue(SpacingProperty, value);
+        }
+
+        public static readonly StyledProperty<object> SelectedValueProperty =
+            AvaloniaProperty.Register<CollapsingSegmentedBar, object>(
+                nameof(SelectedValue), defaultBindingMode: BindingMode.TwoWay);
+
+        /// <summary>The Tag of the selected segment. A value matching no segment selects the first
+        /// one instead — the strip always has exactly one option active.</summary>
+        public object SelectedValue
+        {
+            get => GetValue(SelectedValueProperty);
+            set => SetValue(SelectedValueProperty, value);
+        }
+
+        /// <summary>Raised whenever <see cref="SelectedValue"/> changes, however it was changed.</summary>
+        public event EventHandler SelectionChanged;
+
+        static CollapsingSegmentedBar()
+        {
+            AffectsMeasure<CollapsingSegmentedBar>(SpacingProperty);
+        }
+
+        private static readonly Uri _stylesUri = new("avares://Clowd.Ui/Controls/CollapsingSegmentedBar.axaml");
+
+        private readonly Button _dropdown;
+        private readonly TextBlock _dropdownLabel;
+        private readonly MenuFlyout _flyout;
+        private readonly List<(MenuItem Item, ToggleButton Segment)> _menu = new();
+        private bool _menuDirty = true;
+
+        public CollapsingSegmentedBar()
+        {
+            Styles.Add(new StyleInclude(_stylesUri) { Source = _stylesUri });
+
+            _flyout = new MenuFlyout { Placement = PlacementMode.BottomEdgeAlignedRight };
+
+            _dropdownLabel = new TextBlock { VerticalAlignment = VerticalAlignment.Center };
+
+            _dropdown = new Button
+            {
+                Flyout = _flyout,
+                VerticalAlignment = VerticalAlignment.Center,
+                Content = new StackPanel
+                {
+                    Orientation = Orientation.Horizontal,
+                    Spacing = 6,
+                    Children = { _dropdownLabel, BuildChevron() },
+                },
+            };
+
+            // the segments are declared by the caller and land after this one; arrange places every
+            // child explicitly, so the order in Children does not matter.
+            Children.Add(_dropdown);
+            Children.CollectionChanged += OnChildrenChanged;
+        }
+
+        private Control BuildChevron()
+        {
+            // 32px canvas (AppStyles icon table) stated explicitly, as the icons elsewhere in the app
+            // do it, so the Viewbox scales the whole canvas rather than the glyph's bounding box.
+            var path = new Path
+            {
+                Width = 32,
+                Height = 32,
+                Data = FindGeometry("IconChevronDown"),
+            };
+
+            path.Bind(Shape.FillProperty, this.GetResourceObservable("SemiColorText1"));
+
+            return new Viewbox
+            {
+                Width = 9,
+                Height = 9,
+                VerticalAlignment = VerticalAlignment.Center,
+                Child = path,
+            };
+        }
+
+        private static Geometry FindGeometry(string key)
+        {
+            var app = Application.Current;
+            if (app != null && app.TryGetResource(key, app.ActualThemeVariant, out var res) && res is Geometry geometry)
+                return geometry;
+
+            return null;
+        }
+
+        /// <summary>The caller's segments, in declaration order. The dropdown is a Button, so it
+        /// never turns up here.</summary>
+        private IEnumerable<ToggleButton> Segments()
+        {
+            foreach (var child in Children)
+            {
+                if (child is ToggleButton segment)
+                    yield return segment;
+            }
+        }
+
+        private void OnChildrenChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            // cheaper to re-hook the (handful of) segments than to track adds and removes: a handler
+            // subscribed twice would set the same value twice, so removing first keeps it at one.
+            foreach (var segment in Segments())
+            {
+                segment.Click -= SegmentClicked;
+                segment.Click += SegmentClicked;
+                segment.PropertyChanged -= SegmentPropertyChanged;
+                segment.PropertyChanged += SegmentPropertyChanged;
+            }
+
+            _menuDirty = true;
+            SyncSegmentPositions();
+            EnsureSelection();
+        }
+
+        private void SegmentPropertyChanged(object sender, AvaloniaPropertyChangedEventArgs e)
+        {
+            // a segment the caller hides is not part of the strip any more, so the rounded ends may
+            // have to move to different segments.
+            if (e.Property == IsVisibleProperty)
+                SyncSegmentPositions();
+        }
+
+        /// <summary>Marks the ends of the strip, which is how the theme knows which corners to round
+        /// and which segment draws the left edge of the joined outline. Both classes land on the
+        /// same segment when only one of them is showing.</summary>
+        private void SyncSegmentPositions()
+        {
+            ToggleButton previous = null;
+
+            foreach (var segment in Segments())
+            {
+                if (!segment.IsVisible)
+                {
+                    segment.Classes.Remove("first");
+                    segment.Classes.Remove("last");
+                    continue;
+                }
+
+                segment.Classes.Set("first", previous == null);
+                segment.Classes.Set("last", true);
+
+                previous?.Classes.Set("last", false);
+                previous = segment;
+            }
+        }
+
+        /// <summary>Falls back to the first segment when <see cref="SelectedValue"/> names none of
+        /// them — a strip with nothing active reads as broken, and the first segment is the "show
+        /// everything" one by convention.</summary>
+        private void EnsureSelection()
+        {
+            ToggleButton first = null;
+
+            foreach (var segment in Segments())
+            {
+                first ??= segment;
+                if (Equals(segment.Tag, SelectedValue))
+                {
+                    SyncSelection();
+                    return;
+                }
+            }
+
+            if (first != null)
+                SetCurrentValue(SelectedValueProperty, first.Tag);
+        }
+
+        private void SegmentClicked(object sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            SetCurrentValue(SelectedValueProperty, (sender as Control)?.Tag);
+
+            // clicking the active segment has already unchecked it by the time we get here, and the
+            // property did not change — so re-assert the check state either way.
+            SyncSelection();
+        }
+
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+        {
+            base.OnPropertyChanged(change);
+
+            if (change.Property != SelectedValueProperty)
+                return;
+
+            SyncSelection();
+            SelectionChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        /// <summary>Points the check state, the collapsed label and the menu's tick at the selected
+        /// segment.</summary>
+        private void SyncSelection()
+        {
+            foreach (var segment in Segments())
+            {
+                var selected = Equals(segment.Tag, SelectedValue);
+
+                if (segment.IsChecked != selected)
+                    segment.IsChecked = selected;
+
+                if (!selected)
+                    continue;
+
+                var label = LabelOf(segment);
+                _dropdownLabel.Text = label;
+                ToolTip.SetTip(_dropdown, label);
+                AutomationProperties.SetName(_dropdown, label);
+            }
+
+            foreach (var (item, segment) in _menu)
+                item.Icon = Equals(segment.Tag, SelectedValue) ? BuildCheckGlyph() : null;
+        }
+
+        private void RebuildMenu()
+        {
+            _menuDirty = false;
+            _menu.Clear();
+
+            var items = new List<Control>();
+            foreach (var segment in Segments())
+            {
+                var item = new MenuItem { Header = LabelOf(segment) };
+
+                // the segment stays the source of truth for whether the option applies right now.
+                item.Bind(MenuItem.IsVisibleProperty, segment.GetObservable(IsVisibleProperty));
+                item.Bind(MenuItem.IsEnabledProperty, segment.GetObservable(IsEnabledProperty));
+
+                var source = segment;
+                item.Click += (_, _) =>
+                {
+                    SetCurrentValue(SelectedValueProperty, source.Tag);
+                    SyncSelection();
+                };
+
+                items.Add(item);
+                _menu.Add((item, source));
+            }
+
+            _flyout.ItemsSource = items;
+            SyncSelection();
+        }
+
+        /// <summary>Tick shown beside the active option in the collapsed menu. Stretched rather than
+        /// drawn on its stated canvas: the checkmark fills its own bounding box, so there is no
+        /// padding around it to preserve.</summary>
+        private Control BuildCheckGlyph()
+        {
+            var path = new Path
+            {
+                Data = FindGeometry("IconCheckmark"),
+                Stretch = Stretch.Uniform,
+            };
+
+            path.Bind(Shape.FillProperty, this.GetResourceObservable("SemiColorText1"));
+
+            return new Viewbox { Width = 12, Height = 12, Child = path };
+        }
+
+        private static string LabelOf(ToggleButton segment)
+        {
+            if (segment.Content is string text && !String.IsNullOrEmpty(text))
+                return text;
+
+            if (ToolTip.GetTip(segment) is string tip && !String.IsNullOrEmpty(tip))
+                return tip;
+
+            return AutomationProperties.GetName(segment) ?? "";
+        }
+
+        /// <summary>Width the whole strip needs, and how many of its segments are showing.</summary>
+        private (double Width, int Count) MeasureStrip()
+        {
+            double width = 0;
+            var count = 0;
+
+            foreach (var segment in Segments())
+            {
+                if (!segment.IsVisible)
+                    continue;
+
+                width += segment.DesiredSize.Width;
+                count++;
+            }
+
+            if (count > 1)
+                width += Spacing * (count - 1);
+
+            return (width, count);
+        }
+
+        protected override Size MeasureOverride(Size availableSize)
+        {
+            double height = 0;
+            foreach (var segment in Segments())
+            {
+                if (!segment.IsVisible)
+                    continue;
+
+                segment.Measure(Size.Infinity);
+                height = Math.Max(height, segment.DesiredSize.Height);
+            }
+
+            var (width, count) = MeasureStrip();
+
+            if (_menuDirty)
+                RebuildMenu();
+
+            // measured before the early return below (arrange runs whatever measure left behind, and
+            // it arranges the dropdown either way) and after the menu is built, because the label the
+            // dropdown carries is what makes it as wide as it is.
+            _dropdown.Measure(Size.Infinity);
+
+            // nothing to choose between: take up no space, not even the dropdown's.
+            if (count == 0)
+                return default;
+
+            height = Math.Max(height, _dropdown.DesiredSize.Height);
+
+            // a host that passes a real constraint gets the answer now, and the strip gives up the
+            // width it was not going to use; a Grid Auto column measures with infinity, so there the
+            // decision falls to arrange instead.
+            var fits = width <= availableSize.Width;
+            return new Size(fits ? width : _dropdown.DesiredSize.Width, height);
+        }
+
+        protected override Size ArrangeOverride(Size finalSize)
+        {
+            var (width, count) = MeasureStrip();
+
+            // half a pixel of slack: the width a Grid hands back is the one it measured, and
+            // rounding it against itself must not collapse a strip that actually fits.
+            var collapsed = count > 0 && width > finalSize.Width + 0.5;
+
+            SetShown(_dropdown, collapsed);
+            if (collapsed)
+            {
+                var w = Math.Min(_dropdown.DesiredSize.Width, finalSize.Width);
+                _dropdown.Arrange(new Rect(0, 0, w, finalSize.Height));
+            }
+            else
+            {
+                _dropdown.Arrange(default);
+            }
+
+            // the strip fills the slot from its left edge; where that slot sits is the host's
+            // business (the Recent header aligns the whole bar right).
+            double x = 0;
+
+            foreach (var segment in Segments())
+            {
+                if (!segment.IsVisible)
+                    continue;
+
+                SetShown(segment, !collapsed);
+
+                if (collapsed)
+                {
+                    segment.Arrange(default);
+                    continue;
+                }
+
+                segment.Arrange(new Rect(x, 0, segment.DesiredSize.Width, finalSize.Height));
+                x += segment.DesiredSize.Width + Spacing;
+            }
+
+            return finalSize;
+        }
+
+        /// <summary>Hides a child without touching IsVisible (see the type's remarks) and without
+        /// invalidating layout — this runs from arrange. Focus goes with it, so a collapsed segment
+        /// cannot be tabbed to and pressed while it is not on screen.</summary>
+        private static void SetShown(Control child, bool shown)
+        {
+            child.Opacity = shown ? 1 : 0;
+            child.IsHitTestVisible = shown;
+            child.Focusable = shown;
+        }
+    }
+}

--- a/clowd_ui/Clowd.Ui/Main/IPageHeaderContent.cs
+++ b/clowd_ui/Clowd.Ui/Main/IPageHeaderContent.cs
@@ -1,0 +1,20 @@
+using Avalonia.Controls;
+
+namespace Clowd.UI
+{
+    /// <summary>
+    /// A page that puts a control of its own beside the window's page title — the Recent page's
+    /// filter, which the issue asks for "to the right of the Recent header" and so cannot live in the
+    /// page's own content. The window shows <see cref="HeaderContent"/> while that page is selected
+    /// and clears the slot when another one is.
+    /// </summary>
+    /// <remarks>
+    /// Pages are created once and cached for the window's lifetime, so the same control instance is
+    /// handed back to the header every time its page is selected — implementations should return a
+    /// control they own rather than building a fresh one per call.
+    /// </remarks>
+    public interface IPageHeaderContent
+    {
+        Control HeaderContent { get; }
+    }
+}

--- a/clowd_ui/Clowd.Ui/Main/MainWindow.axaml
+++ b/clowd_ui/Clowd.Ui/Main/MainWindow.axaml
@@ -105,13 +105,24 @@
         <Grid Grid.Row="0" Grid.RowSpan="2" Grid.Column="1" Margin="24,0,0,0" RowDefinitions="Auto,*">
             <!-- The page header lives outside PageHost, so both the title and introduction stay
                  visible while the settings page scrolls underneath them. -->
-            <StackPanel Margin="0,8,16,16" Spacing="8">
-                <TextBlock x:Name="PageTitle" Classes="Subtitle" />
+            <!-- The title keeps only the width it needs (Auto) and the slot beside it takes the
+                 rest, so it is the page's header control — not the title — that has to give way
+                 when the window is narrow. -->
+            <Grid Margin="0,8,16,16" RowDefinitions="Auto,Auto" ColumnDefinitions="Auto,*">
+                <TextBlock x:Name="PageTitle" Classes="Subtitle" VerticalAlignment="Center" />
+                <ContentControl x:Name="PageHeaderContent"
+                                Grid.Column="1"
+                                Margin="16,0,0,0"
+                                HorizontalAlignment="Right"
+                                VerticalAlignment="Center" />
                 <TextBlock x:Name="PageIntro"
+                           Grid.Row="1"
+                           Grid.ColumnSpan="2"
+                           Margin="0,8,0,0"
                            Classes="Body"
                            Opacity="0.7"
                            TextWrapping="Wrap" />
-            </StackPanel>
+            </Grid>
             <TransitioningContentControl x:Name="PageHost" Grid.Row="1">
                 <TransitioningContentControl.PageTransition>
                     <CrossFade Duration="0:0:0.12" />

--- a/clowd_ui/Clowd.Ui/Main/MainWindow.axaml.cs
+++ b/clowd_ui/Clowd.Ui/Main/MainWindow.axaml.cs
@@ -91,7 +91,13 @@ namespace Clowd.UI
             _selectedTab = tab;
             PageTitle.Text = item.Header as string ?? tab.ToString();
             SetPageIntro(tab);
-            PageHost.Content = GetPageForTab(tab);
+
+            var page = GetPageForTab(tab);
+            PageHost.Content = page;
+
+            // a page that carries its own header control (the Recent filter) hands the same instance
+            // over every time it is selected; the slot is emptied for the pages that carry none.
+            PageHeaderContent.Content = (page as IPageHeaderContent)?.HeaderContent;
         }
 
         private void SetPageIntro(SettingsPageTab tab)

--- a/clowd_ui/Clowd.Ui/Main/Pages/RecentSessionsPage.axaml
+++ b/clowd_ui/Clowd.Ui/Main/Pages/RecentSessionsPage.axaml
@@ -172,10 +172,12 @@
     <controls:FadeEdgeScrollViewer>
         <StackPanel Margin="0,0,16,16">
 
-            <!-- zero state: shown until the first capture exists -->
+            <!-- zero state: shown until the first capture exists, and again whenever the header's
+                 filter matches nothing. Its wording is set by UpdateEmptyState, which knows which of
+                 the two it is. -->
             <StackPanel IsVisible="{Binding !Groups.Count}" Margin="0,24,0,0" Spacing="6">
-                <TextBlock Classes="Base" Text="No captures yet" />
-                <TextBlock Opacity="0.7" TextWrapping="Wrap" Text="{Binding EmptyHint}" />
+                <TextBlock x:Name="EmptyTitle" Classes="Base" />
+                <TextBlock x:Name="EmptyDetail" Opacity="0.7" TextWrapping="Wrap" />
             </StackPanel>
 
             <!-- VM-side grouping replaces the WPF CollectionViewSource (decision table #52). -->

--- a/clowd_ui/Clowd.Ui/Main/Pages/RecentSessionsPage.axaml.cs
+++ b/clowd_ui/Clowd.Ui/Main/Pages/RecentSessionsPage.axaml.cs
@@ -10,17 +10,20 @@ using Avalonia;
 using Avalonia.Animation;
 using Avalonia.Animation.Easings;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Data.Converters;
 using Avalonia.Input;
 // Avalonia 12 moved SetTextAsync and friends off IClipboard into extension methods here.
 using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
+using Avalonia.Layout;
 using Avalonia.LogicalTree;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Styling;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using Clowd.UI.Controls;
 using Clowd.UI.Helpers;
 using Clowd.UI.Services;
 
@@ -37,7 +40,18 @@ namespace Clowd.UI
         }
     }
 
-    public partial class RecentSessionsPage : UserControl
+    /// <summary>What the Recent list can be narrowed to (issue #62). Not a partition of the list: a
+    /// screenshot that has been uploaded is both an <see cref="Image"/> and an <see cref="Upload"/>,
+    /// and a text or file upload is only ever the latter.</summary>
+    public enum RecentFilter
+    {
+        All,
+        Image,
+        Recording,
+        Upload,
+    }
+
+    public partial class RecentSessionsPage : UserControl, IPageHeaderContent
     {
         public ObservableCollection<SessionGroupVm> Groups { get; } = new();
 
@@ -54,6 +68,11 @@ namespace Clowd.UI
         }
 
         private readonly DispatcherTimer _regroupTimer;
+
+        // the filter strip shown beside the page title, and what it currently says. The page owns
+        // the control but does not host it — the window's header does (see IPageHeaderContent).
+        private readonly CollapsingSegmentedBar _filterBar;
+        private RecentFilter _filter = RecentFilter.All;
 
         // the row to re-select after a rebuild; see RebuildGroups.
         private SessionInfo _focusedSession;
@@ -75,6 +94,8 @@ namespace Clowd.UI
             InitializeComponent();
             DataContext = this;
 
+            _filterBar = BuildFilterBar();
+
             // regrouping is throttled to 250 ms (decision table #52 / §6) because
             // TrulyObservableCollection raises Reset for every item property change.
             _regroupTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(250) };
@@ -85,6 +106,101 @@ namespace Clowd.UI
             };
 
             RebuildGroups();
+        }
+
+        /// <summary>The filter strip, shown by the window to the right of the "Recent" title.</summary>
+        public Control HeaderContent => _filterBar;
+
+        private CollapsingSegmentedBar BuildFilterBar()
+        {
+            var bar = new CollapsingSegmentedBar
+            {
+                HorizontalAlignment = HorizontalAlignment.Right,
+                VerticalAlignment = VerticalAlignment.Center,
+                Children =
+                {
+                    // the labels are what the strip has to fit side by side, and what the collapsed
+                    // dropdown carries as its own label.
+                    Segment("All", RecentFilter.All, "Show everything"),
+                    Segment("Images", RecentFilter.Image, "Screenshots and images"),
+                    Segment("Recordings", RecentFilter.Recording, "Recordings and GIFs"),
+                    Segment("Uploads", RecentFilter.Upload, "Anything uploaded, or waiting to be"),
+                },
+            };
+
+            // hooked after the segments are in, so the strip settling on its first segment is not
+            // reported as the user changing the filter.
+            bar.SelectionChanged += FilterChanged;
+            return bar;
+
+            static ToggleButton Segment(string label, RecentFilter filter, string tip)
+            {
+                var segment = new ToggleButton { Content = label, Tag = filter };
+                ToolTip.SetTip(segment, tip);
+                return segment;
+            }
+        }
+
+        private void FilterChanged(object sender, EventArgs e)
+        {
+            var selected = _filterBar.SelectedValue is RecentFilter filter ? filter : RecentFilter.All;
+            if (selected == _filter)
+                return;
+
+            _filter = selected;
+
+            // the user is waiting on this one: regroup now rather than on the throttle.
+            _regroupTimer.Stop();
+            RebuildGroups();
+        }
+
+        /// <summary>Moves the filter, keeping the strip and the list in step. A no-op when it is
+        /// already there.</summary>
+        private void SetFilter(RecentFilter filter)
+        {
+            if (_filter == filter)
+                return;
+
+            // _filter first, so the strip's own change notification finds nothing left to do.
+            _filter = filter;
+            _filterBar.SelectedValue = filter;
+
+            _regroupTimer.Stop();
+            RebuildGroups();
+        }
+
+        private bool MatchesFilter(SessionInfo session)
+        {
+            return _filter switch
+            {
+                // a capture or editor session carries no ContentKind at all; an entry the upload
+                // path created names what it holds, and only "image" is one.
+                RecentFilter.Image => !session.IsVideo
+                                      && (!session.IsUploadOnly
+                                          || String.Equals(session.ContentKind, "image", StringComparison.OrdinalIgnoreCase)),
+                RecentFilter.Recording => IsRecording(session),
+                // anything with a link, plus everything the upload path started even if it has no
+                // link (yet, or ever — a failed or cancelled upload still belongs here).
+                RecentFilter.Upload => session.ActiveUpload != null
+                                       || session.AllUploads.Length > 0
+                                       || IsUploadEntry(session),
+                _ => true,
+            };
+        }
+
+        /// <summary>A recording Clowd made — or the GIF converted from one. Both are "video" entries
+        /// carrying the file they wrote; a video *file* someone uploaded is one too, but has no
+        /// VideoPath of its own, which is what tells the two apart.</summary>
+        private static bool IsRecording(SessionInfo session)
+        {
+            return session.IsVideo && !String.IsNullOrEmpty(session.VideoPath);
+        }
+
+        /// <summary>An entry started by uploading something rather than by capturing it: the upload
+        /// path is the only one that sets ContentKind without also writing a VideoPath.</summary>
+        private static bool IsUploadEntry(SessionInfo session)
+        {
+            return session.IsUploadOnly && String.IsNullOrEmpty(session.VideoPath);
         }
 
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
@@ -148,10 +264,12 @@ namespace Clowd.UI
         private void RebuildGroups()
         {
             var sessions = SessionManager.Current.Sessions
+                                         .Where(MatchesFilter)
                                          .OrderByDescending(s => s.CreatedUtc)
                                          .ToArray();
 
             Groups.Clear();
+            UpdateEmptyState(sessions.Length);
 
             SessionGroupVm current = null;
             foreach (var session in sessions)
@@ -173,6 +291,32 @@ namespace Clowd.UI
                 Dispatcher.UIThread.Post(() => TrySelectSession(_focusedSession, scrollIntoView: false), DispatcherPriority.Loaded);
         }
 
+        /// <summary>Words the zero state for whichever kind of empty this is: nothing captured yet
+        /// (where the call to action belongs) or a filter that happens to match nothing.</summary>
+        private void UpdateEmptyState(int matched)
+        {
+            // the zero state is bound to Groups being empty, so there is nothing to say otherwise.
+            if (matched > 0)
+                return;
+
+            if (_filter == RecentFilter.All || SessionManager.Current.Sessions.Count == 0)
+            {
+                EmptyTitle.Text = "No captures yet";
+                EmptyDetail.Text = EmptyHint;
+                return;
+            }
+
+            EmptyTitle.Text = _filter switch
+            {
+                RecentFilter.Image => "No images",
+                RecentFilter.Recording => "No recordings",
+                RecentFilter.Upload => "No uploads",
+                _ => "Nothing to show",
+            };
+
+            EmptyDetail.Text = "Nothing in your recent captures matches this filter — choose \"All\" to see everything.";
+        }
+
         /// <summary>Selects a session's row and scrolls it into view — used to walk the user to the
         /// entry a gif conversion just created. Safe for a session that is not on the page. The row
         /// pulses once it settles, because the user did not ask for this selection and needs pointing
@@ -184,6 +328,11 @@ namespace Clowd.UI
 
             _focusedSession = session;
             _pulseSession = session;
+
+            // the app is walking the user to this entry, so a filter that hides it has to give way —
+            // otherwise a screenshot taken while the list shows Recordings lands on an empty page.
+            if (!MatchesFilter(session))
+                SetFilter(RecentFilter.All);
 
             // a session created moments ago isn't grouped yet: the rebuild is throttled to 250 ms.
             if (!Groups.Any(g => g.Items.Contains(session)))


### PR DESCRIPTION
Closes #62.

A segmented **All / Images / Recordings / Uploads** strip sits to the right of the "Recent" title and narrows the list to one kind of entry. When the header cannot fit it side by side it collapses into a labelled dropdown whose menu offers the same choices (ticking the active one).

### What each filter matches

| Filter | Matches |
| --- | --- |
| Images | entries whose content is an image — captures, editor sessions, uploaded images |
| Recordings | recordings and the GIFs converted from them — a video entry that wrote its own file, which is what tells one from an uploaded video |
| Uploads | anything with an upload link, **plus** everything the file-upload path started even when it has no link yet (or never got one) |

Not a partition: a screenshot that has been uploaded shows under both Images and Uploads.

### The new control

`CollapsingSegmentedBar` is a new control rather than a reuse of `CollapsingButtonBar`, as the issue anticipated. The collapse machinery is the same and taken from it — decision made in arrange as well as measure, children kept in the tree as the menu's source of truth, hidden with opacity rather than `IsVisible` — but a single-select strip has to say *which* option is active when collapsed, so it cannot share that bar's anonymous ⋮ button, and it brings its own chrome because the usual host is the window header rather than the page that declares the segments.

The header slot is new too: the page title lives in `MainWindow`, so a page now offers a header control through `IPageHeaderContent` and the window shows it while that page is selected.

### Also

- The zero state words itself for a filter that matches nothing ("No recordings" + how to get back to All) instead of showing the first-run call to action.
- A selection the app makes on the user's behalf — a new capture, a finished GIF conversion — resets the filter to All, so it never walks them to a row the filter is hiding.

### Verified

Built and run on Windows: the strip renders and filters correctly against synthetic image / uploaded-image / recording / file-upload entries, and the collapsed dropdown and its menu work at narrow window widths.