### PR TITLE
Import and export upload provider settings via the clipboard

### DIFF
--- a/clowd_ui/Clowd.Shared.Tests/UploadSettingsTransferTests.cs
+++ b/clowd_ui/Clowd.Shared.Tests/UploadSettingsTransferTests.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Clowd.Config;
+using Clowd.Upload;
+using Xunit;
+
+namespace Clowd.Shared.Tests
+{
+    public class UploadSettingsTransferTests
+    {
+        private static SettingsUpload NewSettings()
+        {
+            // force the Clowd.Upload assembly into the AppDomain, mirroring App startup
+            _ = typeof(MimeProvider).Assembly;
+
+            var settings = new SettingsUpload();
+            settings.DiscoverProviders();
+            return settings;
+        }
+
+        private static UploadTransferPayload Export(SettingsUpload settings, params string[] typeNames)
+            => settings.ExportProviders(typeNames, "4.0.0", DateTimeOffset.UnixEpoch);
+
+        [Fact]
+        public void RoundTrip_CarriesSettingsDefaultsAndEnabledState()
+        {
+            var source = NewSettings();
+
+            var imgur = source.Providers.Single(p => p.Provider is ImgurUploadProvider);
+            imgur.IsEnabled = true;
+            ((ImgurUploadProvider)imgur.Provider).ClientId = "test-client-id";
+            source.SetDefaultProvider(imgur, SupportedUploadType.Image);
+
+            var s3Info = source.Providers.Single(p => p.Provider is S3UploadProvider);
+            s3Info.IsEnabled = true;
+            var s3 = (S3UploadProvider)s3Info.Provider;
+            s3.AccessKeyId = "AKIAEXAMPLE";
+            s3.SecretAccessKey = "secretsecret";
+            s3.BucketName = "my-bucket";
+            s3.UseCustomEndpoint = true;
+            source.SetDefaultProvider(s3Info, SupportedUploadType.Binary);
+
+            var text = UploadSettingsTransfer.Encode(Export(source, "ImgurUploadProvider", "S3UploadProvider"));
+
+            Assert.True(UploadSettingsTransfer.TryDecode(text, out var payload));
+            Assert.Equal(2, payload.Providers.Count);
+
+            var target = NewSettings();
+            foreach (var kvp in payload.Providers)
+                Assert.True(target.ImportProvider(kvp.Key, kvp.Value));
+
+            var importedImgur = target.Providers.Single(p => p.Provider is ImgurUploadProvider);
+            Assert.True(importedImgur.IsEnabled);
+            Assert.Equal("test-client-id", ((ImgurUploadProvider)importedImgur.Provider).ClientId);
+            Assert.Same(importedImgur, target.GetDefaultProvider(SupportedUploadType.Image));
+
+            var importedS3Info = target.Providers.Single(p => p.Provider is S3UploadProvider);
+            var importedS3 = (S3UploadProvider)importedS3Info.Provider;
+            Assert.True(importedS3Info.IsEnabled);
+            Assert.Equal("AKIAEXAMPLE", importedS3.AccessKeyId);
+            Assert.Equal("secretsecret", importedS3.SecretAccessKey);
+            Assert.Equal("my-bucket", importedS3.BucketName);
+            Assert.True(importedS3.UseCustomEndpoint);
+            Assert.Same(importedS3Info, target.GetDefaultProvider(SupportedUploadType.Binary));
+
+            // and the imported state is mirrored into the persisted config
+            Assert.True(target.ProviderConfig["ImgurUploadProvider"].IsEnabled);
+            Assert.Equal("test-client-id", target.ProviderConfig["ImgurUploadProvider"].Settings["ClientId"]);
+        }
+
+        [Fact]
+        public void ExportedString_IsNotLegible()
+        {
+            var source = NewSettings();
+            var imgur = source.Providers.Single(p => p.Provider is ImgurUploadProvider);
+            ((ImgurUploadProvider)imgur.Provider).ClientId = "super-secret-client-id";
+
+            var text = UploadSettingsTransfer.Encode(Export(source, "ImgurUploadProvider"));
+
+            Assert.DoesNotContain("super-secret-client-id", text, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("Imgur", text, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Encode_ProducesADifferentStringEachTime()
+        {
+            // a fresh nonce per export, so two exports of identical settings are not obviously
+            // the same string
+            var source = NewSettings();
+            var payload = Export(source, "ImgurUploadProvider");
+
+            Assert.NotEqual(UploadSettingsTransfer.Encode(payload), UploadSettingsTransfer.Encode(payload));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("hello world")]
+        [InlineData("aGVsbG8gd29ybGQ=")] // valid base64, wrong magic
+        public void TryDecode_RejectsForeignText(string text)
+        {
+            Assert.False(UploadSettingsTransfer.TryDecode(text, out var payload));
+            Assert.Null(payload);
+        }
+
+        [Fact]
+        public void TryDecode_ToleratesWhitespaceFromWrappedText()
+        {
+            var source = NewSettings();
+            var text = UploadSettingsTransfer.Encode(Export(source, "ImgurUploadProvider"));
+
+            var wrapped = String.Join(Environment.NewLine, Chunk(text, 40));
+            Assert.True(UploadSettingsTransfer.TryDecode("  " + wrapped + "  ", out var payload));
+            Assert.True(payload.Providers.ContainsKey("ImgurUploadProvider"));
+        }
+
+        [Fact]
+        public void TryDecode_RejectsTamperedPayload()
+        {
+            var source = NewSettings();
+            var text = UploadSettingsTransfer.Encode(Export(source, "ImgurUploadProvider"));
+
+            var raw = Convert.FromBase64String(text);
+            raw[^1] ^= 0xff;
+
+            Assert.False(UploadSettingsTransfer.TryDecode(Convert.ToBase64String(raw), out _));
+        }
+
+        [Fact]
+        public void TryDecode_RejectsUnsupportedVersion()
+        {
+            var source = NewSettings();
+            var raw = Convert.FromBase64String(UploadSettingsTransfer.Encode(Export(source, "ImgurUploadProvider")));
+
+            raw[6] = 200; // envelope version byte
+
+            Assert.False(UploadSettingsTransfer.TryDecode(Convert.ToBase64String(raw), out _));
+        }
+
+        [Fact]
+        public void Import_TakesTheDefaultSlotFromWhicheverProviderHeldIt()
+        {
+            var source = NewSettings();
+            var imgur = source.Providers.Single(p => p.Provider is ImgurUploadProvider);
+            imgur.IsEnabled = true;
+            source.SetDefaultProvider(imgur, SupportedUploadType.Image);
+
+            var target = NewSettings();
+            var vgy = target.Providers.Single(p => p.Provider is VgyMeUploadProvider);
+            vgy.IsEnabled = true;
+            target.SetDefaultProvider(vgy, SupportedUploadType.Image);
+
+            UploadSettingsTransfer.TryDecode(
+                UploadSettingsTransfer.Encode(Export(source, "ImgurUploadProvider")), out var payload);
+            target.ImportProvider("ImgurUploadProvider", payload.Providers["ImgurUploadProvider"]);
+
+            Assert.False(vgy.DefaultFor.HasFlag(SupportedUploadType.Image));
+            Assert.Same(
+                target.Providers.Single(p => p.Provider is ImgurUploadProvider),
+                target.GetDefaultProvider(SupportedUploadType.Image));
+        }
+
+        [Fact]
+        public void Import_IgnoresProvidersThisBuildDoesNotHave()
+        {
+            var target = NewSettings();
+
+            var entry = new UploadTransferEntry { Name = "Ghost", IsEnabled = true };
+            Assert.False(target.ImportProvider("GhostUploadProvider", entry));
+            Assert.False(target.ProviderConfig.ContainsKey("GhostUploadProvider"));
+        }
+
+        [Fact]
+        public void Import_IgnoresSettingsKeysThisBuildDoesNotHave()
+        {
+            var target = NewSettings();
+
+            var entry = new UploadTransferEntry
+            {
+                Name = "Imgur",
+                IsEnabled = true,
+                DefaultFor = "Image",
+                Settings = new Dictionary<string, string>
+                {
+                    ["ClientId"] = "known",
+                    ["SomethingFromTheFuture"] = "unknown",
+                },
+            };
+
+            Assert.True(target.ImportProvider("ImgurUploadProvider", entry));
+
+            var imgur = target.Providers.Single(p => p.Provider is ImgurUploadProvider);
+            Assert.True(imgur.IsEnabled);
+            Assert.Equal("known", ((ImgurUploadProvider)imgur.Provider).ClientId);
+        }
+
+        [Fact]
+        public void ParseUploadTypes_KeepsTheNamesItRecognises()
+        {
+            var parsed = UploadSettingsTransfer.ParseUploadTypes("Image, SomethingNewer, Text");
+
+            Assert.True(parsed.HasFlag(SupportedUploadType.Image));
+            Assert.True(parsed.HasFlag(SupportedUploadType.Text));
+            Assert.False(parsed.HasFlag(SupportedUploadType.Video));
+        }
+
+        [Fact]
+        public void ParseUploadTypes_RoundTripsWhatFormatWrites()
+        {
+            var types = SupportedUploadType.Image | SupportedUploadType.Video;
+            var text = UploadSettingsTransfer.FormatUploadTypes(types);
+
+            var parsed = UploadSettingsTransfer.ParseUploadTypes(text);
+            Assert.True(parsed.HasFlag(SupportedUploadType.Image));
+            Assert.True(parsed.HasFlag(SupportedUploadType.Video));
+            Assert.False(parsed.HasFlag(SupportedUploadType.Binary));
+        }
+
+        [Fact]
+        public void ExportProviders_SkipsNamesThatMatchNothing()
+        {
+            var source = NewSettings();
+            var payload = Export(source, "ImgurUploadProvider", "GhostUploadProvider");
+
+            Assert.Equal(new[] { "ImgurUploadProvider" }, payload.Providers.Keys);
+        }
+
+        [Fact]
+        public void ExportProviders_ReadsProvidersTheUserNeverTouched()
+        {
+            // a provider with no ProviderConfig entry yet must still export its live state
+            var source = NewSettings();
+            Assert.False(source.ProviderConfig.ContainsKey("VgyMeUploadProvider"));
+
+            var payload = Export(source, "VgyMeUploadProvider");
+            Assert.True(payload.Providers.ContainsKey("VgyMeUploadProvider"));
+            Assert.Equal("vgy.me", payload.Providers["VgyMeUploadProvider"].Name);
+        }
+
+        private static IEnumerable<string> Chunk(string value, int size)
+        {
+            for (int i = 0; i < value.Length; i += size)
+                yield return value.Substring(i, Math.Min(size, value.Length - i));
+        }
+    }
+}

--- a/clowd_ui/Clowd.Shared/Config/SettingsUpload.cs
+++ b/clowd_ui/Clowd.Shared/Config/SettingsUpload.cs
@@ -203,6 +203,111 @@ namespace Clowd.Config
                 .ToList();
         }
 
+        /// <summary>Looks up the runtime wrapper for a provider by its type name (the key used in
+        /// <see cref="ProviderConfig"/> and in exported strings).</summary>
+        public UploadProviderInfo GetProviderByTypeName(string typeName)
+        {
+            return _providers.FirstOrDefault(p => String.Equals(p.Provider.GetType().Name, typeName, StringComparison.Ordinal));
+        }
+
+        /// <summary>Builds an export payload containing the current state of the named providers.
+        /// Names that match no discovered provider are skipped.</summary>
+        public UploadTransferPayload ExportProviders(IEnumerable<string> typeNames, string appVersion, DateTimeOffset exported)
+        {
+            var payload = new UploadTransferPayload
+            {
+                App = appVersion,
+                Exported = exported,
+            };
+
+            foreach (var typeName in typeNames)
+            {
+                var info = GetProviderByTypeName(typeName);
+                if (info == null)
+                    continue;
+
+                // read from the live provider rather than ProviderConfig: a provider the user has
+                // never touched has no entry there yet.
+                var config = BuildConfig(info);
+
+                payload.Providers[typeName] = new UploadTransferEntry
+                {
+                    Name = info.Provider.Name,
+                    IsEnabled = config.IsEnabled,
+                    DefaultFor = UploadSettingsTransfer.FormatUploadTypes(config.DefaultFor),
+                    Settings = new Dictionary<string, string>(config.Settings, StringComparer.Ordinal),
+                };
+            }
+
+            return payload;
+        }
+
+        /// <summary>
+        /// Replaces one provider's settings with an imported entry, overwriting everything the
+        /// entry carries. Returns false when this build has no provider of that type.
+        /// </summary>
+        /// <remarks>
+        /// Settings keys the entry omits are left alone rather than reset — an export written by an
+        /// older Clowd should not blank out a field it never knew about. Any upload type the entry
+        /// claims a default for is taken away from whichever provider currently holds it, because
+        /// two defaults for the same type is not a state the rest of the code expects.
+        /// </remarks>
+        public bool ImportProvider(string typeName, UploadTransferEntry entry)
+        {
+            if (entry == null)
+                return false;
+
+            var info = GetProviderByTypeName(typeName);
+            if (info == null)
+                return false;
+
+            ApplyConfig(info, new UploadProviderConfig
+            {
+                IsEnabled = entry.IsEnabled,
+                // applied below through SetDefaultProvider so other providers give up the slot
+                DefaultFor = SupportedUploadType.None,
+                Settings = entry.Settings,
+            });
+
+            var defaultFor = UploadSettingsTransfer.ParseUploadTypes(entry.DefaultFor);
+            foreach (var uploadType in _defaultableTypes)
+            {
+                if (defaultFor.HasFlag(uploadType))
+                    SetDefaultProvider(info, uploadType);
+                else
+                    ClearDefaultProvider(info, uploadType);
+            }
+
+            // ApplyConfig/SetDefaultProvider raise PropertyChanged on the wrapper and the provider,
+            // which SyncToConfig mirrors into ProviderConfig — but only for providers that changed.
+            // Sync explicitly so an import that happens to be a no-op still writes the key.
+            SyncToConfig(info);
+            return true;
+        }
+
+        private static UploadProviderConfig BuildConfig(UploadProviderInfo info)
+        {
+            var config = new UploadProviderConfig
+            {
+                IsEnabled = info.IsEnabled,
+                DefaultFor = info.DefaultFor,
+            };
+
+            foreach (PropertyDescriptor pd in TypeDescriptor.GetProperties(info.Provider))
+            {
+                if (pd.IsReadOnly || !pd.IsBrowsable)
+                    continue;
+
+                var value = pd.GetValue(info.Provider);
+                if (value == null)
+                    continue;
+
+                config.Settings[pd.Name] = pd.Converter.ConvertToInvariantString(value);
+            }
+
+            return config;
+        }
+
         private static void ApplyConfig(UploadProviderInfo info, UploadProviderConfig config)
         {
             info.IsEnabled = config.IsEnabled;
@@ -234,25 +339,7 @@ namespace Clowd.Config
         /// and raises PropertyChanged so the UI layer's auto-save persists it.</summary>
         private void SyncToConfig(UploadProviderInfo info)
         {
-            var config = new UploadProviderConfig
-            {
-                IsEnabled = info.IsEnabled,
-                DefaultFor = info.DefaultFor,
-            };
-
-            foreach (PropertyDescriptor pd in TypeDescriptor.GetProperties(info.Provider))
-            {
-                if (pd.IsReadOnly || !pd.IsBrowsable)
-                    continue;
-
-                var value = pd.GetValue(info.Provider);
-                if (value == null)
-                    continue;
-
-                config.Settings[pd.Name] = pd.Converter.ConvertToInvariantString(value);
-            }
-
-            ProviderConfig[info.Provider.GetType().Name] = config;
+            ProviderConfig[info.Provider.GetType().Name] = BuildConfig(info);
             OnPropertyChanged(nameof(ProviderConfig));
         }
 

--- a/clowd_ui/Clowd.Shared/Config/UploadSettingsTransfer.cs
+++ b/clowd_ui/Clowd.Shared/Config/UploadSettingsTransfer.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Clowd.Config
+{
+    /// <summary>One provider's exported state. Deliberately loose: every field is optional and
+    /// unknown fields are ignored on read, so a string written by a newer (or older) Clowd still
+    /// imports whatever it has in common with this build.</summary>
+    public class UploadTransferEntry
+    {
+        /// <summary>The provider's display name at export time, so the import picker can label an
+        /// entry even when this build has no provider of that type.</summary>
+        public string Name { get; set; }
+
+        public bool IsEnabled { get; set; }
+
+        /// <summary>Comma-separated <see cref="SupportedUploadType"/> names rather than the enum
+        /// itself — an unrecognised name is dropped instead of failing the whole import.</summary>
+        public string DefaultFor { get; set; }
+
+        /// <summary>The provider's flattened settings, same shape as
+        /// <see cref="UploadProviderConfig.Settings"/>.</summary>
+        public Dictionary<string, string> Settings { get; set; } = new(StringComparer.Ordinal);
+    }
+
+    /// <summary>The decrypted body of a transfer string.</summary>
+    public class UploadTransferPayload
+    {
+        /// <summary>Payload schema, separate from the envelope version byte. Bumped only when the
+        /// JSON shape changes in a way readers need to know about.</summary>
+        public int Schema { get; set; } = 1;
+
+        /// <summary>Clowd version that produced the string. Informational only.</summary>
+        public string App { get; set; }
+
+        public DateTimeOffset Exported { get; set; }
+
+        /// <summary>Keyed by provider type name (e.g. "ImgurUploadProvider"), matching
+        /// <see cref="SettingsUpload.ProviderConfig"/>.</summary>
+        public Dictionary<string, UploadTransferEntry> Providers { get; set; } = new(StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Packs upload provider settings into a single clipboard-friendly string and back.
+    /// </summary>
+    /// <remarks>
+    /// <para>Wire format is JSON, encrypted with AES-256-GCM, wrapped in a small binary envelope,
+    /// then Base64:</para>
+    /// <code>
+    /// [0..6)   "CLWDUP"  magic
+    /// [6]      version   envelope version, 0-255
+    /// [7..19)  nonce     12 bytes
+    /// [19..35) tag       16 bytes (authenticates the header too, so the version cannot be edited)
+    /// [35..)   ciphertext
+    /// </code>
+    /// <para>The key is compiled into Clowd, so this is <b>obfuscation, not secrecy</b>: anyone
+    /// with a copy of Clowd (or a disassembler) can read an exported string. Its job is only to
+    /// stop credentials being legible to someone who stumbles across the text with no context —
+    /// pasted into the wrong chat window, left in a clipboard manager, and so on. Treat an
+    /// exported string as being as sensitive as the credentials inside it. A baked-in RSA keypair
+    /// would be no stronger for the same reason (both halves have to ship for import to work), and
+    /// RSA cannot encrypt a payload this size without a symmetric key anyway.</para>
+    /// </remarks>
+    public static class UploadSettingsTransfer
+    {
+        /// <summary>Envelope version written by this build.</summary>
+        public const byte CurrentVersion = 1;
+
+        /// <summary>Highest envelope version this build knows how to read.</summary>
+        public const byte MaxSupportedVersion = 1;
+
+        private static readonly byte[] _magic = { (byte)'C', (byte)'L', (byte)'W', (byte)'D', (byte)'U', (byte)'P' };
+
+        private const int HeaderLength = 7; // magic + version byte
+        private const int NonceLength = 12;
+        private const int TagLength = 16;
+
+        // Obfuscation key — see the remarks above before treating this as a secret.
+        private static readonly byte[] _key =
+        {
+            0x9d, 0x41, 0xf6, 0x2a, 0x0b, 0x77, 0xc5, 0x18,
+            0xe3, 0x8a, 0x54, 0x6f, 0x21, 0xbc, 0x90, 0x3d,
+            0x7e, 0x15, 0xa8, 0xcb, 0x62, 0x04, 0xdf, 0x93,
+            0x38, 0xe7, 0x1a, 0x76, 0xc0, 0x4b, 0x85, 0x2f,
+        };
+
+        private static readonly JsonSerializerOptions _json = new()
+        {
+            PropertyNameCaseInsensitive = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        };
+
+        /// <summary>Serializes, encrypts and Base64-encodes <paramref name="payload"/>.</summary>
+        public static string Encode(UploadTransferPayload payload)
+        {
+            if (payload == null)
+                throw new ArgumentNullException(nameof(payload));
+
+            var plaintext = JsonSerializer.SerializeToUtf8Bytes(payload, _json);
+
+            var output = new byte[HeaderLength + NonceLength + TagLength + plaintext.Length];
+            Buffer.BlockCopy(_magic, 0, output, 0, _magic.Length);
+            output[_magic.Length] = CurrentVersion;
+
+            var header = output.AsSpan(0, HeaderLength);
+            var nonce = output.AsSpan(HeaderLength, NonceLength);
+            var tag = output.AsSpan(HeaderLength + NonceLength, TagLength);
+            var cipher = output.AsSpan(HeaderLength + NonceLength + TagLength);
+
+            RandomNumberGenerator.Fill(nonce);
+
+            using var aes = new AesGcm(_key, TagLength);
+            aes.Encrypt(nonce, plaintext, cipher, tag, header);
+
+            return Convert.ToBase64String(output);
+        }
+
+        /// <summary>
+        /// Reverses <see cref="Encode"/>. Returns false — without throwing — for anything that is
+        /// not one of ours: arbitrary clipboard text, a truncated copy, a newer envelope version,
+        /// or a payload that fails authentication.
+        /// </summary>
+        public static bool TryDecode(string text, out UploadTransferPayload payload)
+        {
+            payload = null;
+
+            if (String.IsNullOrWhiteSpace(text))
+                return false;
+
+            byte[] raw;
+            try
+            {
+                // FromBase64String already skips whitespace, so a string that wrapped across lines
+                // on its way through a chat client still decodes.
+                raw = Convert.FromBase64String(text.Trim());
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+
+            if (raw.Length < HeaderLength + NonceLength + TagLength)
+                return false;
+
+            for (int i = 0; i < _magic.Length; i++)
+            {
+                if (raw[i] != _magic[i])
+                    return false;
+            }
+
+            var version = raw[_magic.Length];
+            if (version == 0 || version > MaxSupportedVersion)
+                return false;
+
+            var header = raw.AsSpan(0, HeaderLength);
+            var nonce = raw.AsSpan(HeaderLength, NonceLength);
+            var tag = raw.AsSpan(HeaderLength + NonceLength, TagLength);
+            var cipher = raw.AsSpan(HeaderLength + NonceLength + TagLength);
+
+            var plaintext = new byte[cipher.Length];
+            try
+            {
+                using var aes = new AesGcm(_key, TagLength);
+                aes.Decrypt(nonce, cipher, tag, plaintext, header);
+            }
+            catch (CryptographicException)
+            {
+                return false;
+            }
+
+            try
+            {
+                payload = JsonSerializer.Deserialize<UploadTransferPayload>(plaintext, _json);
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+
+            if (payload == null)
+                return false;
+
+            payload.Providers ??= new Dictionary<string, UploadTransferEntry>(StringComparer.Ordinal);
+            return true;
+        }
+
+        /// <summary>Formats a <see cref="SupportedUploadType"/> for
+        /// <see cref="UploadTransferEntry.DefaultFor"/>.</summary>
+        public static string FormatUploadTypes(SupportedUploadType types) => types.ToString();
+
+        /// <summary>
+        /// Parses <see cref="UploadTransferEntry.DefaultFor"/> a name at a time, ignoring any the
+        /// running build does not know. A whole-string <c>Enum.Parse</c> would reject
+        /// "Image, SomethingNewer" outright and lose the Image default with it.
+        /// </summary>
+        public static SupportedUploadType ParseUploadTypes(string value)
+        {
+            var result = SupportedUploadType.None;
+
+            if (String.IsNullOrWhiteSpace(value))
+                return result;
+
+            foreach (var part in value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (Enum.TryParse<SupportedUploadType>(part, ignoreCase: true, out var parsed))
+                    result |= parsed;
+            }
+
+            return result;
+        }
+    }
+}

--- a/clowd_ui/Clowd.Ui/Dialogs/ProviderMultiSelectDialog.cs
+++ b/clowd_ui/Clowd.Ui/Dialogs/ProviderMultiSelectDialog.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media.Imaging;
+
+namespace Clowd.UI.Dialogs
+{
+    /// <summary>
+    /// A checklist of upload providers, laid out like <see cref="ProviderSelectionDialog"/> but
+    /// picking several at once. Shared by the export and import halves of the upload settings
+    /// transfer, which differ only in their wording and in which rows are selectable.
+    /// </summary>
+    internal static class ProviderMultiSelectDialog
+    {
+        public sealed class Item
+        {
+            /// <summary>Provider type name — the key returned to the caller.</summary>
+            public string Key { get; init; }
+
+            public string Name { get; init; }
+
+            public string Description { get; init; }
+
+            /// <summary>Opens a fresh icon stream, or null when this build has no such provider.</summary>
+            public Func<Stream> Icon { get; init; }
+
+            /// <summary>False greys the row out and makes it unselectable — used for providers
+            /// present in an imported string but unknown to this build.</summary>
+            public bool IsAvailable { get; init; } = true;
+
+            public bool IsCheckedByDefault { get; init; }
+        }
+
+        /// <summary>Shows the picker and returns the checked keys, or null if the user cancelled.</summary>
+        public static async Task<string[]> ShowAsync(
+            Window owner, string title, string heading, string actionLabel, IReadOnlyList<Item> items)
+        {
+            var wnd = new SystemThemedWindow
+            {
+                Title = title,
+                Width = 460,
+                MinWidth = 460,
+                MaxHeight = 640,
+                SizeToContent = SizeToContent.Height,
+                WindowStartupLocation = owner == null ? WindowStartupLocation.CenterScreen : WindowStartupLocation.CenterOwner,
+            };
+
+            var boxes = new List<(Item Item, CheckBox Box)>();
+
+            var list = new StackPanel { Spacing = 2 };
+
+            foreach (var item in items)
+            {
+                var icon = new Image
+                {
+                    Width = 24,
+                    Height = 24,
+                    Stretch = Avalonia.Media.Stretch.Uniform,
+                    VerticalAlignment = VerticalAlignment.Center,
+                };
+
+                try
+                {
+                    using var stream = item.Icon?.Invoke();
+                    if (stream != null)
+                        icon.Source = new Bitmap(stream);
+                }
+                catch {; }
+
+                var text = new StackPanel { Margin = new Avalonia.Thickness(10, 0, 0, 0), VerticalAlignment = VerticalAlignment.Center };
+                text.Children.Add(new TextBlock { Text = item.Name, FontWeight = Avalonia.Media.FontWeight.Bold });
+                if (!String.IsNullOrEmpty(item.Description))
+                {
+                    text.Children.Add(new TextBlock
+                    {
+                        Text = item.Description,
+                        Opacity = 0.8,
+                        TextWrapping = Avalonia.Media.TextWrapping.Wrap,
+                    });
+                }
+
+                var content = new StackPanel { Orientation = Orientation.Horizontal };
+                content.Children.Add(icon);
+                content.Children.Add(text);
+
+                var box = new CheckBox
+                {
+                    Content = content,
+                    IsChecked = item.IsAvailable && item.IsCheckedByDefault,
+                    IsEnabled = item.IsAvailable,
+                    Padding = new Avalonia.Thickness(8, 0, 0, 0),
+                    HorizontalAlignment = HorizontalAlignment.Stretch,
+                    VerticalContentAlignment = VerticalAlignment.Center,
+                };
+
+                boxes.Add((item, box));
+                list.Children.Add(box);
+            }
+
+            var selectAll = new CheckBox
+            {
+                Content = "Select all",
+                IsThreeState = false,
+                Margin = new Avalonia.Thickness(0, 0, 0, 4),
+                IsEnabled = boxes.Any(b => b.Item.IsAvailable),
+            };
+
+            var action = new Button
+            {
+                Content = actionLabel,
+                MinWidth = 90,
+                HorizontalContentAlignment = HorizontalAlignment.Center,
+                IsDefault = true,
+            };
+            action.Classes.Add("Primary");
+
+            // guards the two-way sync between "Select all" and the individual rows, which would
+            // otherwise chase each other (ticking a row updates the header, which re-ticks rows).
+            var syncing = false;
+
+            void RefreshActionState()
+            {
+                action.IsEnabled = boxes.Any(b => b.Box.IsChecked == true);
+            }
+
+            void RefreshSelectAll()
+            {
+                var available = boxes.Where(b => b.Item.IsAvailable).ToArray();
+                syncing = true;
+                selectAll.IsChecked = available.Length > 0 && available.All(b => b.Box.IsChecked == true);
+                syncing = false;
+            }
+
+            foreach (var (_, box) in boxes)
+            {
+                box.IsCheckedChanged += (_, _) =>
+                {
+                    if (syncing)
+                        return;
+
+                    RefreshActionState();
+                    RefreshSelectAll();
+                };
+            }
+
+            selectAll.IsCheckedChanged += (_, _) =>
+            {
+                if (syncing)
+                    return;
+
+                var check = selectAll.IsChecked == true;
+                syncing = true;
+                foreach (var (item, box) in boxes)
+                {
+                    if (item.IsAvailable)
+                        box.IsChecked = check;
+                }
+
+                syncing = false;
+                RefreshActionState();
+            };
+
+            RefreshActionState();
+            RefreshSelectAll();
+
+            var panel = new StackPanel { Margin = new Avalonia.Thickness(24, 16, 24, 12), Spacing = 10 };
+            panel.Children.Add(new TextBlock
+            {
+                Text = heading,
+                TextWrapping = Avalonia.Media.TextWrapping.Wrap,
+                Opacity = 0.8,
+            });
+            panel.Children.Add(selectAll);
+            panel.Children.Add(new ScrollViewer
+            {
+                MaxHeight = 380,
+                HorizontalScrollBarVisibility = Avalonia.Controls.Primitives.ScrollBarVisibility.Disabled,
+                Content = list,
+            });
+
+            string[] result = null;
+            action.Click += (_, _) =>
+            {
+                result = boxes.Where(b => b.Box.IsChecked == true).Select(b => b.Item.Key).ToArray();
+                wnd.Close();
+            };
+
+            var cancel = new Button
+            {
+                Content = "Cancel",
+                MinWidth = 80,
+                HorizontalContentAlignment = HorizontalAlignment.Center,
+                IsCancel = true,
+            };
+            cancel.Click += (_, _) => wnd.Close();
+
+            // footer strip matching MessageDialog / ProviderSelectionDialog (tinted bar, actions right)
+            var buttons = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Right,
+                Spacing = 8,
+                Children = { cancel, action },
+            };
+
+            var footer = new Border
+            {
+                Child = buttons,
+                Padding = new Avalonia.Thickness(16, 10),
+            };
+            footer.Bind(Border.BackgroundProperty, footer.GetResourceObservable("SemiColorFill0"));
+
+            var root = new DockPanel { LastChildFill = true };
+            DockPanel.SetDock(footer, Dock.Bottom);
+            root.Children.Add(footer);
+            root.Children.Add(panel);
+
+            wnd.Content = root;
+
+            if (owner != null && owner != wnd)
+            {
+                await wnd.ShowDialog(owner);
+            }
+            else
+            {
+                var tcs = new TaskCompletionSource();
+                wnd.Closed += (_, _) => tcs.TrySetResult();
+                wnd.Show();
+                await tcs.Task;
+            }
+
+            return result;
+        }
+    }
+}

--- a/clowd_ui/Clowd.Ui/Helpers/Toast.cs
+++ b/clowd_ui/Clowd.Ui/Helpers/Toast.cs
@@ -16,7 +16,7 @@ namespace Clowd.UI.Helpers
     {
         private static readonly ConditionalWeakTable<Window, WindowNotificationManager> _managers = new();
 
-        public static void Show(Window window, string message)
+        public static void Show(Window window, string message, NotificationType type = NotificationType.Success)
         {
             if (window == null || String.IsNullOrEmpty(message))
                 return;
@@ -27,7 +27,7 @@ namespace Clowd.UI.Helpers
                 MaxItems = 3,
             });
 
-            manager.Show(new Notification(null, message, NotificationType.Success, TimeSpan.FromSeconds(2.5)));
+            manager.Show(new Notification(null, message, type, TimeSpan.FromSeconds(2.5)));
         }
 
         /// <summary>A reasonable window to host a toast or borrow a clipboard from when the caller

--- a/clowd_ui/Clowd.Ui/Main/Pages/UploadSettingsPage.axaml.cs
+++ b/clowd_ui/Clowd.Ui/Main/Pages/UploadSettingsPage.axaml.cs
@@ -1,27 +1,204 @@
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Notifications;
 using Avalonia.Controls.Shapes;
 using Avalonia.Input;
+// Avalonia 12 moved TryGetTextAsync and friends off IClipboard into extension methods here.
+using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.VisualTree;
 using Clowd.Config;
 using Clowd.UI.Config;
+using Clowd.UI.Dialogs;
 using Clowd.UI.Helpers;
 using Ursa.Controls;
 
+// Ursa ships a Toast of its own; this page means the app's toast helper.
+using Toast = Clowd.UI.Helpers.Toast;
+
 namespace Clowd.UI.Pages
 {
-    public partial class UploadSettingsPage : UserControl
+    public partial class UploadSettingsPage : UserControl, IPageHeaderContent
     {
+        // the import/export strip shown beside the page title. The page owns the control but does
+        // not host it — the window's header does (see IPageHeaderContent).
+        private readonly Control _transferBar;
+
         public UploadSettingsPage()
         {
             InitializeComponent();
             DataContext = SettingsRoot.Current.Uploads;
+            _transferBar = BuildTransferBar();
+        }
+
+        public Control HeaderContent => _transferBar;
+
+        private Control BuildTransferBar()
+        {
+            var import = new Button { Content = "Import" };
+            ToolTip.SetTip(import, "Read provider settings from a Clowd settings string on the clipboard");
+            import.Click += ImportClicked;
+
+            var export = new Button { Content = "Export" };
+            ToolTip.SetTip(export, "Copy provider settings to the clipboard as a Clowd settings string");
+            export.Click += ExportClicked;
+
+            return new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Right,
+                VerticalAlignment = VerticalAlignment.Center,
+                Spacing = 8,
+                Children = { import, export },
+            };
+        }
+
+        private async void ExportClicked(object sender, RoutedEventArgs e)
+        {
+            var window = TopLevel.GetTopLevel(this) as Window;
+            var uploads = SettingsRoot.Current.Uploads;
+
+            var items = uploads.Providers
+                .Select(p => new ProviderMultiSelectDialog.Item
+                {
+                    Key = p.Provider.GetType().Name,
+                    Name = p.Provider.Name,
+                    Description = p.Provider.Description,
+                    Icon = () => p.Provider.Icon,
+                    // an enabled provider is the one the user has actually configured, so it is
+                    // the one they most likely want to carry to another machine
+                    IsCheckedByDefault = p.IsEnabled,
+                })
+                .ToArray();
+
+            if (items.Length == 0)
+            {
+                Toast.Show(window, "There are no upload providers to export.", NotificationType.Warning);
+                return;
+            }
+
+            var chosen = await ProviderMultiSelectDialog.ShowAsync(
+                window,
+                "Export upload providers",
+                "Choose which providers to copy to the clipboard. The copied text is scrambled so it "
+                + "means nothing to anyone who stumbles across it, but it is not encrypted with a "
+                + "password — it still carries your credentials, so only pass it to people you trust.",
+                "Copy",
+                items);
+
+            if (chosen == null || chosen.Length == 0)
+                return;
+
+            string text;
+            try
+            {
+                var version = typeof(UploadSettingsPage).Assembly.GetName().Version?.ToString();
+                var payload = uploads.ExportProviders(chosen, version, DateTimeOffset.UtcNow);
+                text = UploadSettingsTransfer.Encode(payload);
+            }
+            catch (Exception ex)
+            {
+                SentryConfig.CaptureHandled(ex, "upload.settings-export");
+                await NiceDialog.ShowNoticeAsync(this, NiceDialogIcon.Error, ex.Message, "Export failed");
+                return;
+            }
+
+            var clipboard = window?.Clipboard ?? Toast.GetPrimaryClipboard();
+            if (clipboard == null)
+            {
+                await NiceDialog.ShowNoticeAsync(this, NiceDialogIcon.Error, "The clipboard is not available.", "Export failed");
+                return;
+            }
+
+            await ClipboardImpl.SetClipboardText(clipboard, text);
+            Toast.Show(window, chosen.Length == 1
+                ? "Copied 1 provider to the clipboard."
+                : $"Copied {chosen.Length} providers to the clipboard.");
+        }
+
+        private async void ImportClicked(object sender, RoutedEventArgs e)
+        {
+            var window = TopLevel.GetTopLevel(this) as Window;
+            var uploads = SettingsRoot.Current.Uploads;
+
+            var clipboard = window?.Clipboard ?? Toast.GetPrimaryClipboard();
+            string text = null;
+            if (clipboard != null)
+            {
+                try
+                {
+                    text = await clipboard.TryGetTextAsync();
+                }
+                catch
+                {
+                    // a clipboard held open by another app reads as "nothing of ours" here
+                }
+            }
+
+            if (!UploadSettingsTransfer.TryDecode(text, out var payload) || payload.Providers.Count == 0)
+            {
+                Toast.Show(window, "No provider settings found in the clipboard.", NotificationType.Warning);
+                return;
+            }
+
+            var items = payload.Providers
+                .Select(kvp =>
+                {
+                    var info = uploads.GetProviderByTypeName(kvp.Key);
+                    Func<System.IO.Stream> icon = info == null ? null : () => info.Provider.Icon;
+                    return new ProviderMultiSelectDialog.Item
+                    {
+                        Key = kvp.Key,
+                        Name = info?.Provider.Name ?? kvp.Value.Name ?? kvp.Key,
+                        Description = info != null
+                            ? info.Provider.Description
+                            : "Not supported by this version of Clowd.",
+                        Icon = icon,
+                        IsAvailable = info != null,
+                        IsCheckedByDefault = true,
+                    };
+                })
+                .OrderByDescending(i => i.IsAvailable)
+                .ThenBy(i => i.Name, StringComparer.Ordinal)
+                .ToArray();
+
+            if (items.All(i => !i.IsAvailable))
+            {
+                Toast.Show(
+                    window,
+                    "The clipboard holds Clowd provider settings, but none of those providers exist in this version.",
+                    NotificationType.Warning);
+                return;
+            }
+
+            var chosen = await ProviderMultiSelectDialog.ShowAsync(
+                window,
+                "Import upload providers",
+                "Choose which providers to import. Each one you tick has all of its settings "
+                + "replaced by what is in the clipboard — including whether it is enabled and which "
+                + "uploads it is the default for.",
+                "Import",
+                items);
+
+            if (chosen == null || chosen.Length == 0)
+                return;
+
+            var imported = 0;
+            foreach (var key in chosen)
+            {
+                if (payload.Providers.TryGetValue(key, out var entry) && uploads.ImportProvider(key, entry))
+                    imported++;
+            }
+
+            Toast.Show(window, imported == 1
+                ? "Imported 1 provider."
+                : $"Imported {imported} providers.");
         }
 
         private void DefaultChipClicked(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Closes #66.

Adds **Import** / **Export** buttons beside the Uploads settings title.

- **Export** — multi-select picker (enabled providers ticked by default), copies the chosen providers to the clipboard as one string.
- **Import** — decodes the clipboard, offers only the providers found in it, and overwrites all settings for the ones ticked. Toasts *"No provider settings found in the clipboard."* when there is nothing of ours.

### Format

JSON, AES-256-GCM, `"CLWDUP"` + version byte envelope, Base64. Fresh nonce per export; the tag authenticates the header so the version byte cannot be edited.

### Resilience to settings churn

Payload is keyed by provider type name, same string-keyed shape `UploadProviderConfig` already persists, and every field is optional:

- unknown provider keys — shown greyed in the import picker, skipped on apply
- unknown setting keys — ignored
- absent setting keys — left at their current value, not blanked
- `defaultFor` — parsed a name at a time, so `"Image, SomethingNewer"` still imports Image
- newer envelope version, tampered bytes, or foreign clipboard text — rejected quietly

Importing a default takes that slot off whichever provider held it; two defaults for one type is not a state the rest of the code expects.

### Tests

18 new tests in `UploadSettingsTransferTests`. Full `Clowd.Shared.Tests` suite: 163/163.

Not exercised in the running app.