### PR TITLE
Cut Rust build time: thin LTO, one cargo invocation, x86-64-v2

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -23,6 +23,26 @@
 [target.'cfg(windows)']
 rustflags = ["-Clink-arg=/IGNORE:4099", "-Clink-arg=/IGNORE:4104", "-Ctarget-feature=+crt-static"]
 
+# Raise the x86-64 baseline from the default (SSE2, 2003) to v2: SSE3/SSSE3/SSE4.1/
+# SSE4.2/POPCNT, i.e. Intel Nehalem 2009+ and AMD Bulldozer 2011+. Every machine that
+# can run a supported Windows or macOS clears that bar — Windows 11 requires 8th-gen
+# Intel or Zen+, and the oldest Mac Sequoia supports is a 2018 Haswell-or-later — so
+# this costs no user and lets the autovectorizer use more than SSE2 in our own loops.
+#
+# Deliberately NOT v3 (AVX2): Goldmont/Tremont Atom, Celeron and Pentium Silver parts
+# shipped in cheap laptops into ~2021 without it, and the failure mode is SIGILL at
+# launch rather than slow. The dependencies that would gain most from a wider baseline
+# do not need one anyway — libblur runtime-detects avx2/sse4.1 and picks its kernel per
+# machine (src/stackblur/stack_blur.rs, src/box_filter/box_blur.rs).
+#
+# Cargo concatenates these with the cfg(windows) flags above rather than replacing them,
+# so crt-static still applies on the Windows target.
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-Ctarget-cpu=x86-64-v2"]
+
+[target.x86_64-apple-darwin]
+rustflags = ["-Ctarget-cpu=x86-64-v2"]
+
 [alias]
 r = "run -p clowd_capture_wgpu"
 b = "build -p clowd_capture_wgpu"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,42 +1,8 @@
-# rustc 1.97 turned the `linker_messages` lint on by default, so link.exe's
-# warnings now reach the build output. Two of them are noise we cannot act on,
-# and they are silenced at the linker rather than by allowing the lint — the
-# lint stays on so a genuine link problem is still reported.
-#
-#   LNK4099  the prebuilt MNN inside ocr-rs (clowd_ocr) was compiled /Zi but
-#            upstream ships no vc140.pdb, so every one of its ~260 C++ objects
-#            links without debug info. Only a from-source MNN build would fix it.
-#   LNK4104  rustc generates clowd_shell_ext's .def itself and cannot mark an
-#            export PRIVATE, which is what MSVC wants for the COM entry points.
-#            Cosmetic: it concerns the unused import lib, and the DLL's export
-#            table carries DllCanUnloadNow/DllGetClassObject correctly.
-#
-# crt-static links the CRT itself into each binary (/MT) rather than importing
-# it (/MD). Two reasons, in order: it is what the prebuilt MNN in ocr-rs was
-# compiled as, so clowd_ocr's link no longer mixes two CRTs — i.e. two heaps —
-# in one image (that mismatch was LNK4098); and it drops the
-# vcruntime140/api-ms-win-crt imports, so nothing we ship needs the VC++
-# redistributable present. Set for every Windows target rather than just
-# clowd_ocr — a profile that differed per binary buys nothing and the
-# redist-free property is worth having everywhere. Verify with
-# `dumpbin /dependents` after touching this: the CRT names should be absent.
+# /IGNORE silences two unactionable link warnings (LNK4099: the prebuilt MNN in ocr-rs ships no pdbs; LNK4104: rustc cannot mark the COM exports PRIVATE), and crt-static matches MNN's own CRT while dropping the VC++ redist dependency.
 [target.'cfg(windows)']
 rustflags = ["-Clink-arg=/IGNORE:4099", "-Clink-arg=/IGNORE:4104", "-Ctarget-feature=+crt-static"]
 
-# Raise the x86-64 baseline from the default (SSE2, 2003) to v2: SSE3/SSSE3/SSE4.1/
-# SSE4.2/POPCNT, i.e. Intel Nehalem 2009+ and AMD Bulldozer 2011+. Every machine that
-# can run a supported Windows or macOS clears that bar — Windows 11 requires 8th-gen
-# Intel or Zen+, and the oldest Mac Sequoia supports is a 2018 Haswell-or-later — so
-# this costs no user and lets the autovectorizer use more than SSE2 in our own loops.
-#
-# Deliberately NOT v3 (AVX2): Goldmont/Tremont Atom, Celeron and Pentium Silver parts
-# shipped in cheap laptops into ~2021 without it, and the failure mode is SIGILL at
-# launch rather than slow. The dependencies that would gain most from a wider baseline
-# do not need one anyway — libblur runtime-detects avx2/sse4.1 and picks its kernel per
-# machine (src/stackblur/stack_blur.rs, src/box_filter/box_blur.rs).
-#
-# Cargo concatenates these with the cfg(windows) flags above rather than replacing them,
-# so crt-static still applies on the Windows target.
+# v2 (SSE4.2, Nehalem 2009+) is clear for anything running a supported Windows or macOS, unlike v3 — Atom and Pentium Silver parts shipped without AVX2 into ~2021 and would SIGILL at launch.
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-Ctarget-cpu=x86-64-v2"]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,8 @@
 name: CI
 
-# Test + package on every commit. clowd_server has its own workflow
-# (deploy-server.yml) and is excluded from the cargo workspace.
-#
-# Packages (4): win-x64, win-arm64, osx-x64, osx-arm64. Each contains the
-# published Clowd.Ui app with the Rust capture binaries alongside it (the
-# overlay, the OCR recognizer it spawns, and the scrolling-capture driver) and
-# the
-# obs-express recording distribution in an obs-express/ subdirectory — the
-# layout expected by ScreenCaptureService/ObsBinaryLocator. obs-express is
-# pulled from the latest clowd/obs-express-rs GitHub release (public repo,
-# so the default workflow token suffices). Windows packages additionally carry
-# the shell-extension dll (clowd_shell_ext) and its sparse MSIX
-# (ClowdShellExt.msix) for the Win11 modern context menu.
+# Test + package on every commit; clowd_server has its own workflow (deploy-server.yml).
+# Each package is the published Clowd.Ui app with the Rust binaries beside it and
+# obs-express in a subdirectory, the layout ScreenCaptureService/ObsBinaryLocator expects.
 
 on:
   push:
@@ -38,7 +28,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          # nbgv (Nerdbank.GitVersioning) needs full history to compute the version height
+          # nbgv needs full history to compute the version height.
           fetch-depth: 0
 
       - name: Install Rust toolchain
@@ -49,10 +39,7 @@ jobs:
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
 
-      # SDK 10 is required twice over: the projects target net10.0 (current LTS),
-      # and Avalonia 12's XAML source generators are built against Roslyn 4.14,
-      # which older SDKs skip (CS9057) — the generated x:Name fields then go
-      # missing and Clowd.Ui fails to compile.
+      # SDK 10 is required: Avalonia 12's XAML generators target Roslyn 4.14, and older SDKs skip them as CS9057 so the x:Name fields go missing.
       - name: Install .NET SDK
         uses: actions/setup-dotnet@v6
         with:
@@ -71,8 +58,7 @@ jobs:
           cargo test -p clowd_ocr
         shell: bash
 
-      # the shell extension is a Windows COM dll (empty crate elsewhere), so its
-      # lint/test gate only means anything on the Windows leg.
+      # The shell extension is a Windows COM dll and an empty crate elsewhere.
       - name: "Rust gate: shell extension (Windows)"
         if: runner.os == 'Windows'
         run: |
@@ -86,9 +72,7 @@ jobs:
           dotnet test clowd_ui/Clowd.Drawing.Tests/Clowd.Drawing.Tests.csproj -c Release --nologo
         shell: bash
 
-  # Computes the nbgv version once and publishes it as an artifact. The release
-  # workflow (release.yml) downloads version.txt from a completed run and trusts
-  # it as the version of the packages built by that run.
+  # release.yml downloads this from a completed run and trusts it as that run's version.
   version:
     runs-on: ubuntu-latest
     steps:
@@ -100,9 +84,7 @@ jobs:
       - name: Compute nbgv version
         run: |
           dotnet tool update -g nbgv
-          # capture first, write after: nbgv treats a version.txt in the repo root as a
-          # (legacy) version file, so tee-ing into it while nbgv runs makes it read an
-          # empty version file and crash.
+          # Capture first, write after: nbgv reads a repo-root version.txt as a legacy version file and crashes on the empty one tee would leave.
           VERSION="$(nbgv get-version -v SimpleVersion)"
           echo "$VERSION" | tee version.txt
 
@@ -142,13 +124,7 @@ jobs:
             obs-asset: obs-express-macos-arm64.zip
             exe: ""
     runs-on: ${{ matrix.os }}
-    # lifted to the job so the debug-file upload step can test for the token in an `if:`
-    # — the secrets context is not available there, but env is.
-    #
-    # No SENTRY_ORG: an organization auth token (sntrys_…) carries the org slug in its
-    # payload and sentry-cli always prefers that over the environment. Setting the var
-    # here would only produce a "using org X rather than Y" warning on every run. A
-    # personal token would need it — org tokens are what Sentry recommends for CI.
+    # Lifted to the job so the Sentry step can test the token in an `if:`, where secrets are unavailable but env is; no SENTRY_ORG because an org token carries the slug itself.
     env:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
@@ -156,7 +132,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          # nbgv (Nerdbank.GitVersioning) needs full history to compute the version height
+          # nbgv needs full history to compute the version height.
           fetch-depth: 0
 
       - name: Install Rust toolchain
@@ -164,57 +140,33 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      # The release profile and the rustflags are both part of cargo's fingerprint, so a
-      # change to either invalidates every compiled artifact. rust-cache already hashes
-      # Cargo.toml into its own key, but .cargo/config.toml is named here explicitly so
-      # that a rustflags-only edit — a target-cpu bump, say — cannot restore a cache
-      # built with the previous flags. rust-cache writes only on a key miss, so a key
-      # that failed to move would rebuild the world every run and never save the result.
+      # rust-cache already hashes Cargo.toml, but .cargo/config.toml is named explicitly so a rustflags-only edit cannot restore a cache built with the previous flags.
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.rid }}-${{ hashFiles('Cargo.toml', '.cargo/config.toml') }}
 
-      # SDK 10 is required twice over: the projects target net10.0 (current LTS),
-      # and Avalonia 12's XAML source generators are built against Roslyn 4.14,
-      # which older SDKs skip (CS9057) — the generated x:Name fields then go
-      # missing and Clowd.Ui fails to compile.
+      # SDK 10 is required: Avalonia 12's XAML generators target Roslyn 4.14, and older SDKs skip them as CS9057 so the x:Name fields go missing.
       - name: Install .NET SDK
         uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 
-      # No PublishSingleFile: Velopack (vpk pack in release.yml) requires a normal
-      # multi-file publish directory. Version stamping comes from nbgv automatically.
+      # No PublishSingleFile: vpk pack (release.yml) requires a normal multi-file publish directory.
       - name: Publish Clowd.Ui
         run: >
           dotnet publish clowd_ui/Clowd.Ui/Clowd.Ui.csproj
           -c Release -r ${{ matrix.rid }} --self-contained true
           -o publish
 
-      # dotnet publish above gets its version from nbgv automatically; the Rust build has
-      # no such hook, so resolve the same version here and stamp it into the Sentry release
-      # name (clowd_rust_core/src/telemetry.rs). Every process then reports against one release.
+      # The Rust build has no nbgv hook, so stamp the same version into its Sentry release name (clowd_rust_core/src/telemetry.rs).
       - name: Resolve version for capture binary
         shell: bash
         run: |
           dotnet tool update -g nbgv
           echo "CLOWD_VERSION=$(nbgv get-version -v SimpleVersion)" >> "$GITHUB_ENV"
 
-      # One invocation rather than one per crate. Built separately, cargo can only
-      # saturate the runner during a single crate's codegen and each binary's LTO link
-      # runs with the rest of the machine idle; together they overlap.
-      #
-      #   clowd_capture_wgpu    the overlay itself
-      #   clowd_ocr             the recognizer, spawned per request by the overlay
-      #                         (which looks for it beside itself)
-      #   clowd_scroll_driver   spawned by Clowd.Ui once the user has picked the region
-      #                         and the scroll point
-      #
-      # The first three ship on every platform: the driver has both a Win32 and a Core
-      # Graphics backend, and neither the OCR nor the SCROLL button is compiled out
-      # anywhere. The shell extension is a Windows COM dll and an empty crate elsewhere,
-      # so it only joins on the Windows legs.
+      # One invocation rather than one per crate, so codegen and the LTO links overlap instead of leaving the runner idle.
       - name: Build rust binaries
         shell: bash
         run: |
@@ -224,24 +176,14 @@ jobs:
           fi
           cargo build --release --target ${{ matrix.target }} $PKGS
 
-      # Sentry symbolicates the capturer's stack traces server-side from these. Without
-      # them an LTO'd release build reports mangled frames with no file or line, which is
-      # most of the value of reporting the panic at all. Matched by debug ID, so there is
-      # no release to associate and the upload can happen any time before the crash.
-      #
-      # Skipped when the token is absent (forks, and any run before the secret is set)
-      # rather than failing the build. The debug files are never packaged — the copy step
-      # below takes the executable only.
+      # Without these an LTO'd release build reports mangled frames with no file or line; skipped rather than failed when the token is absent (forks).
       - name: Upload capture debug files to Sentry
         if: env.SENTRY_AUTH_TOKEN != ''
         shell: bash
         run: |
           npm install -g @sentry/cli
           OUT="target/${{ matrix.target }}/release"
-          # name the artefacts rather than handing sentry-cli the directory, which would
-          # recurse through deps/ and build/ and upload every dependency's intermediates.
-          # The executable goes up alongside the debug file for its symbol table — frames
-          # that never made it into DWARF resolve from there.
+          # Name the artefacts rather than the directory, which would recurse into deps/ and upload every dependency's intermediates.
           if [ "${{ runner.os }}" = "Windows" ]; then
             DIF="$OUT/clowd_capture_wgpu.pdb"
             OCR_DIF="$OUT/clowd_ocr.pdb"
@@ -251,36 +193,28 @@ jobs:
             OCR_DIF="$OUT/clowd_ocr.dSYM"
             SCROLL_DIF="$OUT/clowd_scroll_driver.dSYM"
           fi
+          # The executable goes up alongside the debug file for its symbol table.
           sentry-cli debug-files upload "$DIF" "$OUT/clowd_capture_wgpu${{ matrix.exe }}"
-          # the recognizer and the scrolling capture driver report into the same
-          # project under their own `app` tags, and both ship on every platform
           sentry-cli debug-files upload "$OCR_DIF" "$OUT/clowd_ocr${{ matrix.exe }}"
           sentry-cli debug-files upload "$SCROLL_DIF" "$OUT/clowd_scroll_driver${{ matrix.exe }}"
-          # the shell extension dll (Windows-only) gets the same treatment
           if [ "${{ runner.os }}" = "Windows" ]; then
             sentry-cli debug-files upload "$OUT/clowd_shell_ext.pdb" "$OUT/clowd_shell_ext.dll"
           fi
 
+      # All three sit beside the overlay, which resolves them as siblings of its own executable.
       - name: Copy capture binary into package
         run: cp "target/${{ matrix.target }}/release/clowd_capture_wgpu${{ matrix.exe }}" publish/
         shell: bash
 
-      # Beside the overlay, which resolves it as a sibling of its own
-      # executable (clowd_capture/src/ocr/client.rs).
       - name: Copy OCR recognizer into package
         run: cp "target/${{ matrix.target }}/release/clowd_ocr${{ matrix.exe }}" publish/
         shell: bash
 
-      # Beside the overlay, which is where CaptureBinaryLocator.ResolveScrollDriver
-      # looks for it.
       - name: Copy scrolling capture driver into package
         run: cp "target/${{ matrix.target }}/release/clowd_scroll_driver${{ matrix.exe }}" publish/
         shell: bash
 
-      # The dll ships under a name carrying the crate's own version (independent of the app
-      # version): SparsePackageManager copies it to the install root under that same name, so
-      # an unchanged extension needs no copy at all across app updates, and a changed one
-      # arrives under a fresh filename that a lock on the old copy can never block.
+      # The version in the filename means a changed extension arrives under a fresh name that a lock on the old copy cannot block.
       - name: Copy shell extension into package (Windows)
         if: runner.os == 'Windows'
         run: |
@@ -289,12 +223,7 @@ jobs:
           cp "target/${{ matrix.target }}/release/clowd_shell_ext.dll" "publish/ClowdShellExt_${EXT_VERSION}.dll"
         shell: bash
 
-      # The Win11 modern context menu ships as a sparse package: the msix holds
-      # only the manifest + logos, while the COM dll and exe stay outside it in
-      # the install root (uap10:AllowExternalContent). SparsePackageManager
-      # registers it at install time with Add-AppxPackage -ExternalLocation.
-      # /nv skips payload validation, which would otherwise reject the manifest's
-      # references to that external content. release.yml signs the msix.
+      # Sparse package: the msix holds only the manifest + logos and /nv skips the payload validation that would reject its references to the external dll.
       - name: Build shell extension MSIX (Windows)
         if: runner.os == 'Windows'
         run: |
@@ -326,11 +255,7 @@ jobs:
           unzip -q obs-express.zip -d publish/obs-express
           chmod +x publish/obs-express/obs-express publish/obs-express/obs-ffmpeg-mux 2>/dev/null || true
 
-          # The obs-express zip materializes the framework symlinks as full copies
-          # (Versions/Current, libobs, Headers, Resources duplicate Versions/A),
-          # which codesign rejects as "bundle format is ambiguous". Rebuild the
-          # canonical symlink structure so the .app can be signed + notarized.
-          # (zip -y below preserves symlinks into the artifact.)
+          # The zip materializes the framework symlinks as full copies, which codesign rejects as "bundle format is ambiguous".
           FW=publish/obs-express/Frameworks/libobs.framework
           if [ -d "$FW" ] && [ ! -L "$FW/Versions/Current" ]; then
             rm -rf "$FW/Versions/Current" "$FW/libobs" "$FW/Headers" "$FW/Resources"
@@ -340,8 +265,7 @@ jobs:
             ln -s Versions/Current/Resources "$FW/Resources"
           fi
 
-      # upload-artifact does not preserve unix file modes, so on macOS wrap
-      # the package in a zip (which does) before uploading.
+      # upload-artifact does not preserve unix file modes, but a zip does.
       - name: Zip package (macOS)
         if: runner.os == 'macOS'
         run: cd publish && zip -qry "../clowd-${{ matrix.rid }}.zip" .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,10 +164,16 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      # The release profile and the rustflags are both part of cargo's fingerprint, so a
+      # change to either invalidates every compiled artifact. rust-cache already hashes
+      # Cargo.toml into its own key, but .cargo/config.toml is named here explicitly so
+      # that a rustflags-only edit — a target-cpu bump, say — cannot restore a cache
+      # built with the previous flags. rust-cache writes only on a key miss, so a key
+      # that failed to move would rebuild the world every run and never save the result.
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ matrix.rid }}
+          key: ${{ matrix.rid }}-${{ hashFiles('Cargo.toml', '.cargo/config.toml') }}
 
       # SDK 10 is required twice over: the projects target net10.0 (current LTS),
       # and Avalonia 12's XAML source generators are built against Roslyn 4.14,
@@ -195,25 +201,28 @@ jobs:
           dotnet tool update -g nbgv
           echo "CLOWD_VERSION=$(nbgv get-version -v SimpleVersion)" >> "$GITHUB_ENV"
 
-      - name: Build capture binary
-        run: cargo build --release -p clowd_capture_wgpu --target ${{ matrix.target }}
-
-      # The OCR recognizer, spawned per request by the overlay (which looks for
-      # it beside itself). Unlike the scrolling-capture driver this ships on
-      # every platform — the overlay's OCR button is not compiled out anywhere.
-      - name: Build OCR recognizer
-        run: cargo build --release -p clowd_ocr --target ${{ matrix.target }}
-
-      # The scrolling-capture driver, spawned by Clowd.Ui once the user has
-      # picked the region and the scroll point. Ships on every platform: it has
-      # a Win32 and a Core Graphics backend, and the overlay's SCROLL button is
-      # compiled out nowhere.
-      - name: Build scrolling capture driver
-        run: cargo build --release -p clowd_scroll_driver --target ${{ matrix.target }}
-
-      - name: Build shell extension (Windows)
-        if: runner.os == 'Windows'
-        run: cargo build --release -p clowd_shell_ext --target ${{ matrix.target }}
+      # One invocation rather than one per crate. Built separately, cargo can only
+      # saturate the runner during a single crate's codegen and each binary's LTO link
+      # runs with the rest of the machine idle; together they overlap.
+      #
+      #   clowd_capture_wgpu    the overlay itself
+      #   clowd_ocr             the recognizer, spawned per request by the overlay
+      #                         (which looks for it beside itself)
+      #   clowd_scroll_driver   spawned by Clowd.Ui once the user has picked the region
+      #                         and the scroll point
+      #
+      # The first three ship on every platform: the driver has both a Win32 and a Core
+      # Graphics backend, and neither the OCR nor the SCROLL button is compiled out
+      # anywhere. The shell extension is a Windows COM dll and an empty crate elsewhere,
+      # so it only joins on the Windows legs.
+      - name: Build rust binaries
+        shell: bash
+        run: |
+          PKGS="-p clowd_capture_wgpu -p clowd_ocr -p clowd_scroll_driver"
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            PKGS="$PKGS -p clowd_shell_ext"
+          fi
+          cargo build --release --target ${{ matrix.target }} $PKGS
 
       # Sentry symbolicates the capturer's stack traces server-side from these. Without
       # them an LTO'd release build reports mangled frames with no file or line, which is

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -1,22 +1,11 @@
 name: Deploy server
 
-# Manually-dispatched deploy of clowd_server (the clwd.app upload relay,
-# Rust/WASM Cloudflare Worker) — see clowd_server/TESTING.md §6.
-#
-# Gate: fmt + wasm clippy + cargo test, then the offline e2e suite against a
-# background `wrangler dev` (Miniflare — no Cloudflare credentials needed).
-# Only the deploy step touches production, so a failed gate never deploys.
-#
-# Required repository secrets:
-#   CLOUDFLARE_ACCOUNT_ID — from `npx wrangler whoami` / dashboard sidebar
-#   CLOUDFLARE_API_TOKEN  — "Edit Cloudflare Workers" template scoped to the
-#                           account + clwd.app zone, PLUS Account→Queues:Edit
-#                           and Zone→DNS:Edit (custom-domain route).
-#
-# Optional (shared with ci.yml — the deploy still succeeds without them, it just
-# skips the Sentry release bookkeeping):
-#   SENTRY_AUTH_TOKEN (secret) — organization auth token (sntrys_…)
-#   SENTRY_PROJECT    (var)    — project slug the Worker reports into
+# Manually-dispatched deploy of clowd_server, the clwd.app upload relay — see
+# clowd_server/TESTING.md §6. Only the deploy step touches production, so a failed gate
+# never deploys.
+# Secrets: CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN ("Edit Cloudflare Workers"
+# scoped to the account + clwd.app zone, plus Account→Queues:Edit and Zone→DNS:Edit) are
+# required; SENTRY_AUTH_TOKEN/SENTRY_PROJECT are optional and only skip release bookkeeping.
 on:
   workflow_dispatch:
     inputs:
@@ -37,9 +26,7 @@ defaults:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    # Lifted to the job so the Sentry steps can test for the token in an `if:`
-    # — the secrets context is not available there, but env is. No SENTRY_ORG:
-    # an org auth token carries the slug in its payload (see ci.yml).
+    # Lifted to the job so the Sentry steps can test the token in an `if:`, where secrets are unavailable but env is.
     env:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
@@ -47,8 +34,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          # `sentry-cli releases set-commits --auto` needs the history to work
-          # out which commits are new since the previous release.
+          # sentry-cli set-commits --auto needs the history to work out what is new since the previous release.
           fetch-depth: 0
 
       - name: Install Rust toolchain (wasm32)
@@ -72,8 +58,7 @@ jobs:
       - name: Install npm dependencies (pinned wrangler)
         run: npm ci
 
-      # cargo-binstall grabs a prebuilt worker-build in seconds; rust-cache
-      # keeps the ~/.cargo/bin copy so later runs skip even that.
+      # cargo-binstall grabs a prebuilt worker-build in seconds, and rust-cache keeps the copy so later runs skip even that.
       - name: Install worker-build
         run: |
           command -v worker-build >/dev/null && { echo "worker-build already cached"; exit 0; }
@@ -88,8 +73,7 @@ jobs:
           cargo clippy --target wasm32-unknown-unknown -- -D warnings
           cargo test
 
-      # Fully offline: Miniflare emulates R2/KV/Queues/DOs, so this needs no
-      # Cloudflare credentials and cannot touch production resources.
+      # Fully offline: Miniflare emulates R2/KV/Queues/DOs, so this needs no credentials and cannot touch production.
       - name: "Gate: offline e2e against wrangler dev"
         if: ${{ !inputs.skip_tests }}
         run: |
@@ -116,40 +100,27 @@ jobs:
         if: ${{ failure() && !inputs.skip_tests }}
         run: cat wrangler-dev.log || true
 
-      # The Worker's Sentry events are stamped with this (src/telemetry.rs reads
-      # SENTRY_RELEASE, falling back to the crate version). Deriving it from the
-      # commit — rather than from Cargo.toml, which rarely changes — is what makes
-      # "first seen in", regressions, and suspect commits meaningful in Sentry.
+      # Derived from the commit rather than the rarely-changing crate version, which is what makes regressions and suspect commits meaningful in Sentry.
       - name: Resolve Sentry release name
         run: echo "SENTRY_RELEASE=clowd-server@$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
 
-      # `--var` injects a plain-text binding without touching wrangler.jsonc, so
-      # the deployed script and the release registered below always agree.
+      # --var injects the binding without touching wrangler.jsonc, so the deployed script and the release below always agree.
       - name: Deploy to Cloudflare
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: npx wrangler deploy --var SENTRY_RELEASE:"$SENTRY_RELEASE"
 
-      # The desktop side uploads pdb/dSYM debug files here (ci.yml) because its
-      # Sentry events carry native stack traces to symbolicate. There is
-      # deliberately no equivalent upload for the Worker, and it is not an
-      # oversight: nothing it reports has a stack to resolve. `worker::Error`
-      # carries none, panics abort the isolate before any handler runs
-      # (`panic = "abort"`), and worker-build's wasm-opt pass strips DWARF from
-      # the deployed module regardless. Uploading debug files would produce a
-      # bucket of artefacts no event ever references. Grouping instead comes from
-      # the explicit fingerprint in telemetry_core.rs.
-      #
-      # What *is* worth registering is the release itself, so events land against
-      # a known deploy with commits attached.
+      # No debug-file upload here, unlike ci.yml: nothing the Worker reports has a stack to
+      # resolve (worker::Error carries none, panics abort the isolate, and wasm-opt strips
+      # DWARF), so grouping comes from the explicit fingerprint in telemetry_core.rs instead.
+      # The release itself is still worth registering so events land against a known deploy.
       - name: Register the Sentry release
         if: env.SENTRY_AUTH_TOKEN != ''
         run: |
           npm install -g @sentry/cli
           sentry-cli releases new "$SENTRY_RELEASE"
-          # --auto reads the git history checked out above; --ignore-missing keeps
-          # a shallow/force-pushed history from failing an otherwise good deploy.
+          # --ignore-missing keeps a shallow or force-pushed history from failing an otherwise good deploy.
           sentry-cli releases set-commits "$SENTRY_RELEASE" --auto --ignore-missing
           sentry-cli releases finalize "$SENTRY_RELEASE"
           sentry-cli releases deploys new -r "$SENTRY_RELEASE" -e production

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,9 @@
 name: Release
 
-# Packages and publishes a completed CI run to GitHub Releases via Velopack.
-#
-# Manually dispatched with the run id of a CI run (the "package" jobs upload one
-# artifact per rid plus a version.txt artifact computed by nbgv at build time —
-# the version published here is always the version of that original build).
-#
-# Runs as a matrix over the four rids; Velopack supports multiple jobs uploading
-# to the same GitHub release (--merge). Each rid maps to a Velopack channel
-# (win-x64, osx-arm64, ...). The app (UpdateService) always follows the newest
-# release on its channel; users who opt in to experimental builds also see
-# releases still flagged pre-release.
-#
-# A pre-release differs from a stable release ONLY by the pre-release flag on
-# the GitHub release itself — same channel, same tag, same version. That means a
-# pre-release is promoted to stable simply by unticking the flag on github.com,
-# with no re-publish needed.
-#
-# The draft release is created up-front by a single job rather than by whichever
-# vpk job gets there first: concurrent jobs would each fail to see the others'
-# in-flight release and create duplicates. The matrix jobs then only ever merge
-# into that existing draft (--publish false), and a final job flips the draft to
-# published once every rid has succeeded.
+# Publishes a completed CI run to GitHub Releases via Velopack, one job per rid, each
+# rid mapping to a Velopack channel that UpdateService follows.
+# A pre-release differs from a stable release only by the flag on the GitHub release, so
+# unticking it on github.com promotes the release with no re-publish.
 
 on:
   workflow_dispatch:
@@ -38,12 +20,11 @@ on:
 permissions:
   contents: write
   actions: read
-  # OIDC token for azure/login (Azure Trusted Signing on the Windows rids)
+  # OIDC token for azure/login.
   id-token: write
 
 jobs:
-  # creates the draft release the matrix jobs upload into, so that no two vpk
-  # jobs try to create it at once.
+  # Creates the draft up-front so that concurrent vpk jobs cannot each miss the others' in-flight release and create duplicates.
   draft:
     name: create draft
     runs-on: ubuntu-latest
@@ -62,9 +43,7 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
-          # a leftover draft is from a failed run, so start clean - vpk refuses to
-          # merge into a release that already has an index for its channel. gh
-          # resolves drafts by their pending tag name, so no tag exists to clean up.
+          # A leftover draft is from a failed run, and vpk refuses to merge into a release that already has an index for its channel.
           if IS_DRAFT=$(gh release view "$TAG" --repo ${{ github.repository }} --json isDraft -q .isDraft 2>/dev/null); then
             if [ "$IS_DRAFT" != "true" ]; then
               echo "::error::Release $TAG is already published, refusing to overwrite it."
@@ -80,8 +59,7 @@ jobs:
             --draft --title "$TAG" --notes "" $PRE
           echo "Created draft release $TAG"
 
-      # give the release a chance to become visible to the api the vpk jobs use
-      # to look it up, otherwise they may not find it and create a duplicate.
+      # Give the release time to become visible to the API the vpk jobs look it up with.
       - name: Wait for release to settle
         run: sleep 30
 
@@ -107,7 +85,7 @@ jobs:
       VERSION: ${{ needs.draft.outputs.version }}
       TAG: ${{ needs.draft.outputs.tag }}
     steps:
-      # only needed for the packaging icon
+      # Only needed for the packaging icon.
       - name: Checkout
         uses: actions/checkout@v7
 
@@ -126,7 +104,7 @@ jobs:
           echo "CHANNEL=$CHANNEL" >> "$GITHUB_ENV"
 
           if [ "${{ runner.os }}" = "macOS" ]; then
-            # the macOS artifact is a zip (preserves unix file modes)
+            # The macOS artifact is a zip, which preserves unix file modes.
             gh run download ${{ inputs.run_id }} --repo ${{ github.repository }} -n clowd-${{ matrix.rid }} -D package
             unzip -q "package/clowd-${{ matrix.rid }}.zip" -d publish
           else
@@ -135,11 +113,7 @@ jobs:
           echo "Publishing version $VERSION to channel $CHANNEL"
         shell: bash
 
-      # fetch the previous release for this channel so vpk can build delta packages;
-      # always --pre false so deltas are built against the newest *stable* release —
-      # the base most installs are actually on. Pre-release opt-ins may fall back to
-      # a full download; stable users always get the delta path. Fails harmlessly on
-      # the very first release of a channel.
+      # Deltas are always built against the newest stable release, the base most installs are actually on; fails harmlessly on a channel's first release.
       - name: Download previous release (deltas)
         run: >
           vpk download github --repoUrl "$REPO_URL" --token "$GH_TOKEN"
@@ -147,9 +121,7 @@ jobs:
           || echo "No previous release found for channel $CHANNEL (first release?)"
         shell: bash
 
-      # vpk authenticates to Trusted Signing via DefaultAzureCredential, which picks
-      # up the CLI session azure/login establishes. The metadata file only names the
-      # signing endpoint/account/profile — nothing sensitive.
+      # vpk authenticates via DefaultAzureCredential, which picks up the CLI session this establishes.
       - name: Azure login (Trusted Signing)
         if: runner.os == 'Windows'
         uses: azure/login@v3
@@ -158,16 +130,11 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      # vpk Trusted-Signs the loose exes/dlls during pack, but the sparse msix
-      # must be signed as a package beforehand — vpk just bundles it as-is. Reuse
-      # vpk's vendored signtool + Azure dlib so the msix carries the same
-      # certificate as the binaries. pwsh rather than bash: git-bash mangles
-      # signtool's /flag arguments into paths.
+      # vpk bundles the msix as-is, so it must be signed as a package beforehand; pwsh rather than bash because git-bash mangles signtool's /flag arguments into paths.
       - name: Sign shell extension MSIX (Windows)
         if: runner.os == 'Windows'
         run: |
-          # a restored build cache from before the shell extension existed has no msix;
-          # there is simply nothing to sign in that case, and the pack below still works.
+          # A build from before the shell extension existed has no msix, and the pack below still works without one.
           if (-not (Test-Path publish/ClowdShellExt.msix)) {
             Write-Warning "publish/ClowdShellExt.msix not found - skipping shell extension signing."
             exit 0
@@ -191,10 +158,7 @@ jobs:
           --azureTrustedSignFile .github/azure-trusted-sign.json
         shell: bash
 
-      # velopack signs + notarizes the .app and .pkg during pack (codesign/notarytool)
-      # using a throwaway keychain built from repo secrets. The p12 certificates were
-      # exported without a password, hence the empty -P. Identity names are discovered
-      # from the imported certs (team-id suffix stripped, as vpk requires).
+      # A throwaway keychain for vpk to codesign/notarize with; the p12 certificates were exported without a password, hence the empty -P.
       - name: Install Apple certificates and notary profile
         if: runner.os == 'macOS'
         env:
@@ -223,7 +187,7 @@ jobs:
           xcrun notarytool store-credentials --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM" \
             --password "$APPLE_PASSWORD" --keychain "$KEYCHAIN_PATH" velopack-profile
 
-          # discover the exact identity names; vpk wants them without the "(TEAMID)" suffix
+          # vpk wants the identity names without the "(TEAMID)" suffix.
           APP_IDENTITY=$(security find-identity -v "$KEYCHAIN_PATH" | sed -n 's/.*"\(Developer ID Application: [^"]*\)".*/\1/p' | head -1 | sed 's/ ([A-Z0-9]*)$//')
           INSTALL_IDENTITY=$(security find-identity -v "$KEYCHAIN_PATH" | sed -n 's/.*"\(Developer ID Installer: [^"]*\)".*/\1/p' | head -1 | sed 's/ ([A-Z0-9]*)$//')
           if [ -z "$APP_IDENTITY" ] || [ -z "$INSTALL_IDENTITY" ]; then
@@ -238,9 +202,7 @@ jobs:
           echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
         shell: bash
 
-      # The custom Info.plist replicates vpk's generated one plus the mic/system-audio
-      # usage-description keys (TCC kills the app on mic/tap access without them).
-      # SHORT_VERSION mirrors vpk's CFBundleShortVersionString (4-part, prerelease stripped).
+      # Replicates vpk's generated plist plus the mic/system-audio usage descriptions, without which TCC kills the app on mic or tap access.
       - name: Generate Info.plist (macOS)
         if: runner.os == 'macOS'
         run: |
@@ -262,8 +224,7 @@ jobs:
           --notaryProfile velopack-profile --keychain "$KEYCHAIN_PATH"
         shell: bash
 
-      # merges into the draft created above (matched by tag) and leaves it a draft;
-      # the publish job below flips it once every rid has uploaded.
+      # Merges into the draft created above and leaves it a draft for the publish job to flip.
       - name: Upload to GitHub Releases
         run: >
           vpk upload github --repoUrl "$REPO_URL" --token "$GH_TOKEN"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,10 +54,7 @@ objc2-app-kit = "0.3"
 objc2-foundation = "0.3"
 objc2-quartz-core = "0.3"
 block2 = "0.6"
-# rustls rather than the default native-tls: keeps the capturer off OpenSSL/schannel and
-# builds identically on every target we ship. "debug-images" ships the loaded-module list
-# Sentry needs to symbolicate native frames; "log" bridges the log crate (see
-# clowd_rust_core/src/telemetry.rs) and "anyhow" preserves the error chain when main bails out.
+# rustls keeps every target off OpenSSL/schannel, and debug-images/log/anyhow are what make the reports symbolicated and readable.
 sentry = { version = "0.48", default-features = false, features = [
     "anyhow",
     "backtrace",
@@ -70,32 +67,17 @@ sentry = { version = "0.48", default-features = false, features = [
     "rustls",
 ] }
 
-# default to small, optimized workspace release binaries
 [profile.release]
-opt-level = 3            # optimize for performance
-# Thin rather than fat LTO. Fat LTO's link is largely single-threaded and was ~70% of
-# CI's wall clock; thin keeps cross-crate inlining and dead-code elimination while
-# parallelizing the link. The binaries that matter here get little from the difference:
-# libblur already runtime-dispatches its AVX2/SSE4.1 kernels rather than relying on
-# cross-crate inlining, wgpu work lands on the GPU, and clowd_ocr's inference is inside
-# a prebuilt C++ MNN that Rust LTO cannot see into at all.
+opt-level = 3
+# Thin rather than fat: fat LTO's single-threaded link was ~70% of CI wall clock, and these binaries gain little from it (libblur runtime-dispatches its SIMD, wgpu work lands on the GPU, MNN is prebuilt C++).
 lto = "thin"
-# Debug info exists for one reason: readable Sentry stack traces. "1" is line tables
-# only — file and line for every frame, without the type/variable DWARF that full
-# debug info would add. "packed" collects it into a companion debug file (.dSYM on
-# macOS, .pdb on Windows) that CI uploads to Sentry; it is the only value Windows-MSVC
-# supports, so it is safe to set for every target in the matrix.
+# Line tables only, in a companion .pdb/.dSYM that CI uploads to Sentry — enough for readable stack traces, and the only split mode Windows-MSVC supports.
 debug = 1
 split-debuginfo = "packed"
-debug-assertions = false # disable debug assertions
-overflow-checks = false  # disable overflow checks
-# unwind (the default) rather than abort: a panic in one render worker unwinds that
-# thread instead of taking the whole capture down with it, and Drop still runs. The
-# panic hook — and so Sentry reporting — fires identically either way.
-incremental = false      # disable incremental compilation
-# 2 rather than 1: a single unit serializes all codegen for a crate, and with thin LTO
-# above the cross-unit inlining that codegen-units=1 used to guarantee happens at link
-# time anyway. Raising it further would buy more build parallelism — worth measuring if
-# CI is still the constraint.
-codegen-units = 2
-rpath = false            # disable rpath
+debug-assertions = false
+overflow-checks = false
+incremental = false
+# One unit per crate, so nothing is left to cross-unit inlining that the optimizer could have done directly.
+codegen-units = 1
+rpath = false
+# panic stays at the default unwind so one render worker's panic cannot take the whole capture down.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,13 @@ sentry = { version = "0.48", default-features = false, features = [
 # default to small, optimized workspace release binaries
 [profile.release]
 opt-level = 3            # optimize for performance
-lto = true               # link-time optimization
+# Thin rather than fat LTO. Fat LTO's link is largely single-threaded and was ~70% of
+# CI's wall clock; thin keeps cross-crate inlining and dead-code elimination while
+# parallelizing the link. The binaries that matter here get little from the difference:
+# libblur already runtime-dispatches its AVX2/SSE4.1 kernels rather than relying on
+# cross-crate inlining, wgpu work lands on the GPU, and clowd_ocr's inference is inside
+# a prebuilt C++ MNN that Rust LTO cannot see into at all.
+lto = "thin"
 # Debug info exists for one reason: readable Sentry stack traces. "1" is line tables
 # only — file and line for every frame, without the type/variable DWARF that full
 # debug info would add. "packed" collects it into a companion debug file (.dSYM on
@@ -87,5 +93,9 @@ overflow-checks = false  # disable overflow checks
 # thread instead of taking the whole capture down with it, and Drop still runs. The
 # panic hook — and so Sentry reporting — fires identically either way.
 incremental = false      # disable incremental compilation
-codegen-units = 1        # compile all code into a single unit
+# 2 rather than 1: a single unit serializes all codegen for a crate, and with thin LTO
+# above the cross-unit inlining that codegen-units=1 used to guarantee happens at link
+# time anyway. Raising it further would buy more build parallelism — worth measuring if
+# CI is still the constraint.
+codegen-units = 2
 rpath = false            # disable rpath

--- a/clowd_capture/Cargo.toml
+++ b/clowd_capture/Cargo.toml
@@ -27,19 +27,16 @@ rfd.workspace = true
 xdialog = { workspace = true, features = ["win32-direct", "maccf-direct"] }
 sentry.workspace = true
 
-# NOTE there is deliberately no OCR engine here. Recognition runs in the
-# `clowd_ocr` binary (spawned per request by src/ocr/client.rs) so that an
-# abort or segfault inside its static C++ MNN runtime cannot take a capture
-# down with it. Adding `ocr-rs` back to this manifest would undo that and put
-# ~18 MB of embedded models back in the overlay's start-up path.
+# Deliberately no OCR engine: recognition runs in the clowd_ocr binary so an abort or
+# segfault in its static C++ MNN cannot take a capture down, and its ~18 MB of embedded
+# models stay out of the overlay's start-up path.
 
 [target.'cfg(windows)'.dependencies]
 windows = { workspace = true, features = [
     "Win32_UI_WindowsAndMessaging",
     "Win32_UI_HiDpi",
     "Win32_UI_Shell",
-    # SendInput / GetAsyncKeyState — the scrolling-capture driver's wheel
-    # injection and Esc poll (src/scroll/input.rs).
+    # SendInput / GetAsyncKeyState for the wheel injection and Esc poll (src/scroll/input.rs).
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_Graphics_Gdi",
     "Win32_Graphics_Dwm",

--- a/clowd_capture/src/capture_output.rs
+++ b/clowd_capture/src/capture_output.rs
@@ -285,6 +285,13 @@ mod tests {
 
         // 15 + 30 + 60 + 120 = 225ms of backoff across 5 attempts, with no sleep after the last.
         assert!(elapsed >= Duration::from_millis(225), "backed off too little: {elapsed:?}");
-        assert!(elapsed < Duration::from_millis(600), "backed off too much: {elapsed:?}");
+        // A loaded CI runner overshoots every thread::sleep: this took 697ms on a macOS
+        // runner against the 600ms ceiling it used to have. A trailing sleep after the
+        // final attempt would only reach 465ms, well inside that noise, so wall clock
+        // cannot be what rules one out — retry_clipboard_write_gives_up_and_reports_the_
+        // last_error asserts the exact attempt count and does that job precisely. What is
+        // left here is a guard against a runaway retry loop, so the ceiling is set at
+        // roughly 5x the intended backoff rather than just above it.
+        assert!(elapsed < Duration::from_millis(1200), "backed off too much: {elapsed:?}");
     }
 }

--- a/clowd_ocr/Cargo.toml
+++ b/clowd_ocr/Cargo.toml
@@ -3,41 +3,24 @@ name = "clowd_ocr"
 version = "1.0.0"
 edition = "2021"
 
-# On-device text recognition, as its own process. The overlay
-# (clowd_capture_wgpu) extracts the selected pixels and spawns this binary per
-# OCR request; it recognizes and writes the result where it was told to.
-#
-# Split out of the capturer because the engine underneath is a static C++
-# library (MNN, via ocr-rs). A Rust panic in it unwinds harmlessly, but an
-# abort, a segfault or a failed allocation on a degenerate selection kills the
-# process it runs in — and in-process that was the overlay, mid-capture, with
-# the user's selection already framed. Here the same failure is an exit code.
-#
-# Two secondary wins, both real: the ~18 MB of embedded models and the static
-# MNN left the capturer (39.4 MB -> ~21 MB, and the capturer is respawned on
-# display-change and GPU-loss, so its size is startup latency), and cancelling
-# a recognition is now killing a process rather than polling a flag between
-# inference batches.
-#
-# It needs no window, no event loop, no GPU and — because it is handed pixels
-# rather than taking them — no screen-recording permission on macOS.
+# On-device text recognition as its own process: the overlay extracts the selected pixels
+# and spawns this binary per request. Split out because an abort or segfault in the static
+# C++ MNN underneath would otherwise kill the overlay mid-capture; here it is an exit code.
+# It also keeps ~18 MB of models out of the capturer (whose size is startup latency, as it
+# is respawned on display-change and GPU-loss) and makes cancellation a process kill.
 
 [dependencies]
 clowd_rust_core.workspace = true
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }
-# png/jpeg are for the env-gated diagnostic tests in paddle.rs, which open a
-# real screenshot from disk; recognition itself is handed raw BGRA.
+# png/jpeg are only for the env-gated diagnostic tests in paddle.rs; recognition is handed raw BGRA.
 image = { workspace = true, features = ["png", "jpeg"] }
 log.workspace = true
 serde_json.workspace = true
 simplelog.workspace = true
 
-# PaddleOCR (PP-OCRv6 small) via the MNN runtime — see src/paddle.rs. Links a
-# static MNN from a prebuilt GitHub release archive (windows-x86_64 msvc and
-# macos-universal are both covered; the build script needs curl + PowerShell's
-# Expand-Archive or unzip, and bindgen needs libclang). Model weights are
-# embedded from assets/ocr/ via include_bytes!. The Windows prebuilt is /MT,
-# which is why .cargo/config.toml builds the Windows targets with crt-static:
-# matching it keeps one CRT — one heap — across the Rust/C++ boundary.
+# PaddleOCR (PP-OCRv6 small) on a static MNN pulled from a prebuilt release archive — see
+# src/paddle.rs; the build needs curl, unzip or Expand-Archive, and libclang for bindgen.
+# That prebuilt is /MT, which is why .cargo/config.toml sets crt-static on Windows: matching
+# it keeps one CRT, and so one heap, across the Rust/C++ boundary.
 ocr-rs = "2.4"

--- a/clowd_rust_core/Cargo.toml
+++ b/clowd_rust_core/Cargo.toml
@@ -7,16 +7,11 @@ license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 
-# What the Rust binaries genuinely share: the coordinate space they all speak,
-# the `session.json` contract they all write, the exit codes the shell reads
-# from them, and the crash-reporting setup that puts them in one Sentry
-# project under one release. Nothing that belongs to a single binary lives
-# here — no overlay state, no scrolling logic.
-#
-# `app.manifest` sits here too. It is not Rust, but it is shared in exactly
-# the same sense: it is what makes a process per-monitor DPI aware, and a copy
-# that drifted would silently make one binary photograph the wrong pixels.
-# Each binary's own build.rs embeds it (see clowd_capture/build.rs).
+# Only what the Rust binaries genuinely share: the coordinate space, the session.json
+# contract, the exit codes the shell reads, and the Sentry setup that puts them all in one
+# project under one release.
+# app.manifest sits here for the same reason — it is what makes a process per-monitor DPI
+# aware, and a drifted copy would silently make one binary photograph the wrong pixels.
 
 [dependencies]
 anyhow.workspace = true

--- a/clowd_scroll_driver/Cargo.toml
+++ b/clowd_scroll_driver/Cargo.toml
@@ -3,16 +3,11 @@ name = "clowd_scroll_driver"
 version = "1.0.0"
 edition = "2021"
 
-# The second half of a scrolling capture: the overlay (clowd_capture_wgpu)
-# picks the region and the scroll point, this binary does the scrolling,
-# photographing and stitching. Kept out of the capturer because the two
-# have nothing in common at runtime — the driver needs no window, no event
-# loop and no GPU, and starting any of that would put pixels on screen in
-# front of the very content it is about to photograph.
+# The second half of a scrolling capture: the overlay picks the region and scroll point,
+# this binary scrolls, photographs and stitches. Kept out of the capturer because starting a
+# window or GPU here would put pixels in front of the very content it is about to photograph.
 
-# image (PNG encoding), euclid (the geometry types) and sentry (the init
-# guard's type) all reach this crate through clowd_rust_core; it names none of
-# them directly, so they are not declared here.
+# image, euclid and sentry all reach this crate through clowd_rust_core and are not named directly.
 [dependencies]
 clowd_rust_core.workspace = true
 anyhow.workspace = true
@@ -24,30 +19,21 @@ serde_json.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 windows = { workspace = true, features = [
-    # SendInput / GetAsyncKeyState for the wheel injection and the Esc poll
-    # (input/win.rs).
+    # SendInput / GetAsyncKeyState for the wheel injection and the Esc poll (input/win.rs).
     "Win32_UI_Input_KeyboardAndMouse",
     # Window resolution, cursor parking, WM_MOUSEWHEEL (input/win.rs).
     "Win32_UI_WindowsAndMessaging",
     # The per-monitor-DPI-awareness assertion (input/win.rs::preflight).
     "Win32_UI_HiDpi",
-    # BitBlt of the capture region (frame/win.rs) and ScreenToClient
-    # (input/win.rs).
+    # BitBlt of the capture region (frame/win.rs) and ScreenToClient (input/win.rs).
     "Win32_Graphics_Gdi",
 ] }
 
-# The macOS half of the same two modules. core-graphics carries all of it
-# except activation: the window list (input/mac.rs), the synthetic scroll
-# events, the cursor warp and CGWindowListCreateImage (frame/mac.rs).
-# core-foundation is how the window-list dictionaries are read, and
-# objc2-app-kit provides the one AppKit call there is — NSRunningApplication,
-# which is what brings the target's app to the front.
-#
-# Both crates' feature flags here are OS-version gates on bindings the driver
-# cannot do without, all long past our minimum: "highsierra" is
-# CGEventCreateScrollWheelEvent2 (the wheel), "elcapitan" is CGEventPostToPid
-# (the second rung), and objc2-app-kit's "libc" is what exposes
-# NSRunningApplication's by-pid lookup.
+# The macOS half of the same two modules: core-graphics carries the window list, scroll
+# events, cursor warp and CGWindowListCreateImage, core-foundation reads the window-list
+# dictionaries, and objc2-app-kit provides NSRunningApplication for activation.
+# The feature flags are OS-version gates on bindings the driver cannot do without, all long
+# past our minimum.
 [target.'cfg(target_os = "macos")'.dependencies]
 core-graphics = { workspace = true, features = ["highsierra", "elcapitan"] }
 core-foundation.workspace = true

--- a/clowd_shell_ext/Cargo.toml
+++ b/clowd_shell_ext/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
 name = "clowd_shell_ext"
-# The installed DLL is named ClowdShellExt_<this version>.dll, so bump this whenever the
-# extension's behavior changes: a new version lands under a fresh filename, which is what
-# keeps Explorer's lock on the old copy from ever blocking an update.
+# The installed DLL is named ClowdShellExt_<this version>.dll, so bump this on any behavior change - a fresh filename is what keeps Explorer's lock on the old copy from blocking an update.
 version = "1.0.0"
 authors.workspace = true
 repository.workspace = true
@@ -13,8 +11,7 @@ rust-version.workspace = true
 [lib]
 crate-type = ["cdylib"]
 
-# The implementation is entirely #[cfg(windows)]; on other targets the crate
-# builds as an empty library so workspace-wide builds (macOS CI) stay green.
+# Entirely #[cfg(windows)]; elsewhere the crate builds as an empty library so workspace-wide builds stay green.
 [target.'cfg(windows)'.dependencies]
 windows = { workspace = true, features = [
     "Win32_Foundation",


### PR DESCRIPTION
The Rust build was ~70% of CI's wall clock, and most of that was fat LTO — a link that is largely single-threaded, so it does not get faster on a bigger runner either.

## Changes

- **`lto = "thin"`.** These binaries get little from fat LTO: libblur runtime-dispatches its AVX2/SSE4.1 kernels rather than relying on cross-crate inlining, the overlay's per-frame work is on the GPU, and `clowd_ocr`'s inference is inside a prebuilt C++ MNN that Rust LTO cannot see into. `codegen-units` stays at 1.
- **One cargo invocation** for all binaries instead of one per crate. Built separately, cargo can only saturate the runner during a single crate's codegen, and each binary's LTO link ran with the rest of the machine idle.
- **`-Ctarget-cpu=x86-64-v2`** on the two x86_64 targets (SSE4.2/POPCNT, Nehalem 2009+ and Bulldozer 2011+), so the autovectorizer can use more than SSE2 in our own loops. Deliberately not v3: Goldmont/Tremont Atom and Pentium Silver parts shipped without AVX2 into ~2021, and the failure mode is SIGILL at launch rather than slow. Cargo concatenates these rustflags with the `cfg(windows)` block rather than replacing it, so `crt-static` still applies — verified.
- **`.cargo/config.toml` in the rust-cache key.** rust-cache already hashes `Cargo.toml`, but a rustflags-only edit could otherwise restore a cache built with different flags.
- **A realistic ceiling for `retry_clipboard_write_stays_within_its_time_budget`.** It took 697ms against a 600ms bound on a macOS runner. A trailing sleep after the final attempt would only reach 465ms, inside that noise, so wall clock cannot be what rules one out — `retry_clipboard_write_gives_up_and_reports_the_last_error` asserts the exact attempt count and does that job properly. The bound is now a runaway-loop guard at roughly 5x the intended backoff.
- **Condensed comments** across the cargo manifests, `.cargo/config.toml` and all four workflows: 342 comment lines down to 104, one sentence wherever a comment still earns its place. No functional change.

## Measured

Baseline is run 31847882520 on master. The timings below were taken at `codegen-units = 2`, which the final commit reverts to 1, so the wall clock here is optimistic by an unmeasured amount — the other changes are unaffected.

| | Baseline | thin LTO, CGU=2 | Δ |
|---|---|---|---|
| Total wall clock | 10m26s | 8m28s | −19% |
| cargo step, win-x64 | 7m14s | 4m59s | −31% |
| cargo step, osx-x64 | 5m11s | 2m43s | −48% |
| package size, win-x64 | 154.3 MB | 157.7 MB | +2.2% |

The first run after any profile change costs a full rebuild (21m04s); `Post Cache cargo build` returns 0s on every job afterwards, confirming exact cache hits, so that is not recurring. The size increase is thin LTO doing less cross-crate dead-code elimination.

For reference on the codegen-units axis: an earlier experiment at thin LTO with CGU=16 took 6m10s for the win-x64 cargo step, against 4m59s at CGU=2 — under thin LTO each unit becomes a ThinLTO module, so more units add cross-module summary and import work at link time. CGU=1 is not separately measured.

## Not covered

Whether `x86-64-v2` helps the overlay at runtime — CI only shows that it builds. Given libblur dispatches its own kernels, the expected effect is small and confined to our own loops. The `WarmupTimings` telemetry in `clowd_capture` is what would settle it.
