### PR TITLE
Attach the capturer's log to capture-crash reports

### DIFF
--- a/clowd_ui/Clowd.Ui/Services/CaptureProcessHost.cs
+++ b/clowd_ui/Clowd.Ui/Services/CaptureProcessHost.cs
@@ -912,10 +912,9 @@ namespace Clowd.UI
             // issue; the specifics ride along in Data.
             var crash = new InvalidOperationException(message);
             crash.Data["exit_code"] = exitCode?.ToString(CultureInfo.InvariantCulture) ?? "unknown";
-            crash.Data["chatter"] = Tail(GetLog());
-            var hostLog = TryReadHostLog();
-            if (hostLog != null)
-                crash.Data["host_log"] = Tail(hostLog);
+            // Full chatter and log file as the process-log.txt attachment: this fires only after
+            // every respawn has failed, so it is the one report that has to carry why.
+            SentryConfig.AttachProcessLog(crash, ("chatter", GetLog()), ("capture-host.log", TryReadHostLog()));
             SentryConfig.CaptureHandled(crash, "capture.host-crash");
         }
 
@@ -1073,26 +1072,6 @@ namespace Clowd.UI
                 Debug.WriteLine("[CaptureHost] failed to read the capture host log: " + ex.Message);
                 return null;
             }
-        }
-
-        /// <summary>The last few lines of a log — the failure is always at the end, after the
-        /// routine startup lines.</summary>
-        private static string Tail(string text)
-        {
-            if (String.IsNullOrWhiteSpace(text))
-                return "No diagnostic output was captured.";
-
-            var lines = new List<string>();
-            foreach (var raw in text.Replace("\r\n", "\n").Split('\n'))
-            {
-                var line = raw.TrimEnd();
-                if (line.Length > 0)
-                    lines.Add(line);
-            }
-
-            const int maxLines = 15;
-            var start = Math.Max(0, lines.Count - maxLines);
-            return String.Join("\n", lines.GetRange(start, lines.Count - start));
         }
 
         private void AppendLog(string line)

--- a/clowd_ui/Clowd.Ui/Services/ScreenCaptureService.cs
+++ b/clowd_ui/Clowd.Ui/Services/ScreenCaptureService.cs
@@ -254,19 +254,22 @@ namespace Clowd.UI
 
                         // The capturer reports its own panics, but it cannot report the ways it dies
                         // without running Rust code — a native fault in a GPU driver, an abort out of
-                        // an FFI frame, or a kill. Its exit code and stderr are all that survives
+                        // an FFI frame, or a kill. Its exit code and log are all that survives
                         // those, so report from this side. Keep the message free of the exit code so
                         // Sentry groups every capturer death into one issue; the specifics ride along
                         // in Data.
                         var crash = new InvalidOperationException("Capture process exited unexpectedly");
                         crash.Data["exit_code"] = process.ExitCode;
-                        crash.Data["stderr"] = SummarizeTail(stderr);
-                        if (captureLog != null)
-                            crash.Data["capture_log"] = SummarizeTail(captureLog);
+                        // Both logs in full, as the process-log.txt attachment. A death of that kind
+                        // writes nothing to stderr, and the session log is the only place the adapter
+                        // it selected is named — truncating either to fit inline in Data is what
+                        // leaves these reports unactionable.
+                        SentryConfig.AttachProcessLog(crash, ("stderr", stderr), ("capture.log", captureLog));
                         SentryConfig.CaptureHandled(crash, "capture.process-crash");
 
                         await NiceDialog.ShowNoticeAsync(null, NiceDialogIcon.Error,
-                            $"The screen capture tool exited unexpectedly (code {process.ExitCode}).\n\n{SummarizeTail(stderr)}",
+                            $"The screen capture tool exited unexpectedly (code {process.ExitCode})." +
+                            $"\n\n{SummarizeDiagnostics(stderr, captureLog)}",
                             "Screen capture failed");
                         return;
                     }
@@ -367,19 +370,16 @@ namespace Clowd.UI
         {
             Debug.WriteLine($"Capture host died mid-capture (code {crash.ExitCode}):\n{crash.Log}");
 
-            var chatter = SummarizeTail(crash.Log);
             var hostLog = CaptureProcessHost.TryReadHostLog();
             CaptureSessionDispatcher.DeleteSessionDir(sessionDir);
 
             var reported = new InvalidOperationException("Capture process exited unexpectedly");
             reported.Data["exit_code"] = crash.ExitCode?.ToString(CultureInfo.InvariantCulture) ?? "unknown";
-            reported.Data["stderr"] = chatter;
-            if (hostLog != null)
-                reported.Data["capture_log"] = SummarizeTail(hostLog);
+            SentryConfig.AttachProcessLog(reported, ("chatter", crash.Log), ("capture-host.log", hostLog));
             SentryConfig.CaptureHandled(reported, "capture.process-crash");
 
             await NiceDialog.ShowNoticeAsync(null, NiceDialogIcon.Error,
-                $"The screen capture tool exited unexpectedly.\n\n{chatter}",
+                $"The screen capture tool exited unexpectedly.\n\n{SummarizeDiagnostics(crash.Log, hostLog)}",
                 "Screen capture failed");
         }
 
@@ -402,6 +402,14 @@ namespace Clowd.UI
         [System.Runtime.InteropServices.DllImport("user32.dll")]
         [System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.System32)]
         private static extern bool AllowSetForegroundWindow(int dwProcessId);
+
+        /// <summary>Picks what to put in front of the user: the capturer's stderr when it managed to
+        /// say something, and otherwise the log file it left behind. A process that dies without
+        /// running Rust code — a native fault in a GPU driver, a kill — writes nothing to stderr, and
+        /// "No diagnostic output was captured." is a dead end when the log file was there all
+        /// along.</summary>
+        private static string SummarizeDiagnostics(string stderr, string log)
+            => String.IsNullOrWhiteSpace(stderr) ? SummarizeTail(log) : SummarizeTail(stderr);
 
         /// <summary>Condenses the capturer's captured stderr (or log file) into the tail few
         /// lines for an error dialog — the failure (a shader error, a panic) is always at the

--- a/clowd_ui/Clowd.Ui/Util/SentryConfig.cs
+++ b/clowd_ui/Clowd.Ui/Util/SentryConfig.cs
@@ -152,6 +152,69 @@ namespace Clowd
             return null;
         }
 
+        /// <summary>Cap on the assembled log. A per-session capture log is a few KB, but the warm
+        /// host's rolling log has no such bound — and a multi-megabyte attachment helps nobody.
+        /// Trimmed from the front: the failure is always at the end.</summary>
+        private const int MaxProcessLogChars = 256 * 1024;
+
+        /// <summary>
+        /// Stows a child process's output on <paramref name="ex"/> under <see cref="ProcessLogKey"/>,
+        /// so <see cref="CaptureHandled"/> uploads it as the <c>process-log.txt</c> attachment no
+        /// matter how many layers up the exception is finally reported.
+        /// </summary>
+        /// <param name="ex">The exception about to be reported.</param>
+        /// <param name="sections">
+        /// Labelled log sources in the order they should appear — put the most diagnostic last,
+        /// since both the size cap above and Sentry's inline <c>process_log_tail</c> keep the end.
+        /// Null and blank sections are skipped, so a caller can pass an optional log file without
+        /// checking for it first.
+        /// </param>
+        /// <remarks>
+        /// Prefer this to parking a log in <see cref="Exception.Data"/> directly: <c>Data</c> is
+        /// serialized inline into the event body, so anything stored there has to be cut down to a
+        /// few lines to fit — which is how a crash report arrives carrying nothing that explains the
+        /// crash. Small scalars (an exit code, a frame count) are still fine in <c>Data</c>.
+        /// </remarks>
+        public static void AttachProcessLog(Exception ex, params (string Label, string Content)[] sections)
+        {
+            if (ex is null || sections is null)
+                return;
+
+            try
+            {
+                // first writer wins, matching TakeProcessLog's "nearest log to the failure" search:
+                // an inner frame knows more about what died than the layer re-reporting it.
+                if (ex.Data.Contains(ProcessLogKey))
+                    return;
+
+                var builder = new StringBuilder();
+                foreach (var (label, content) in sections)
+                {
+                    if (String.IsNullOrWhiteSpace(content))
+                        continue;
+
+                    if (builder.Length > 0)
+                        builder.Append('\n');
+                    builder.Append("===== ").Append(label).Append(" =====\n")
+                           .Append(content.TrimEnd()).Append('\n');
+                }
+
+                if (builder.Length == 0)
+                    return;
+
+                var log = builder.ToString();
+                if (log.Length > MaxProcessLogChars)
+                    log = "[earlier output trimmed]\n" + log.Substring(log.Length - MaxProcessLogChars);
+
+                ex.Data[ProcessLogKey] = log;
+            }
+            catch
+            {
+                // Exception.Data may be read-only or reject writes for exotic exception types;
+                // losing the log must never lose the event itself.
+            }
+        }
+
         /// <summary>
         /// <see cref="CaptureHandled"/> for a call site whose failure mode includes "the network
         /// didn't work": transient faults (see <see cref="IsTransientNetworkFailure"/>) are dropped,


### PR DESCRIPTION
## Problem

"Capture process exited unexpectedly" reports reach Sentry carrying nothing that explains the crash.

[CLOWD-2](https://twtech.sentry.io/issues/CLOWD-2) is the live example, and it's what's behind #74: five events from one user on `clowd@4.1.34` / Windows 10.0.19045, exit code **-1073741819** (`0xC0000005`, `STATUS_ACCESS_VIOLATION`). Every one of them says only *"No diagnostic output was captured."* I checked both events with the Sentry API — **no attachments**.

## Cause

`SentryConfig.ProcessLogKey` exists for exactly this case. Put a child process's log in `ex.Data[ProcessLogKey]` and `CaptureHandled` lifts it out and uploads it as a `process-log.txt` attachment — so a log too large for the event body still reaches triage. Its own docstring says it exists because *"exited unexpectedly / timed out events are undiagnosable without it (CLOWD-Z, CLOWD-C)."*

It was wired into `ObsCapturer`, `ScrollCapturePage` and `ScrollDriver` — but **never into either capture path**. Those parked the log in `Exception.Data` under ad-hoc `stderr` / `capture_log` / `chatter` / `host_log` keys, where it had to be cut to 15 lines to fit inline, and where nothing indexes it. The two reports that most need the log were the only ones not sending it.

## Change

- New `SentryConfig.AttachProcessLog(ex, params (string Label, string Content)[])` — assembles labelled sections into one payload under `ProcessLogKey`, skipping blank sections, capped at 256 KB and trimmed from the front (the failure is always at the end).
- Wire it into all three sites: the one-shot exit, `ReportWarmCaptureCrashAsync`, and the warm host's `ReportGaveUp`.
- `exit_code` stays in `Data` — a small scalar belongs there.
- Drop the now-unused `Tail` helper from `CaptureProcessHost`.

**Error dialog also falls back to the log file.** A process killed by an access violation never runs its Rust error path, so stderr is empty — but the capturer mirrors its log into the session dir, and that file was sitting there the whole time. Rather than telling the user there was no diagnostic output, `SummarizeDiagnostics` shows the log tail when stderr is silent.

## Why it matters here

`capture.log` carries the `selected adapter: "<name>" (vendor=… device=…)` line from `gpu/device.rs:64`. With this in place, the next report of #74 names the GPU and shows how far startup got — which is what decides whether the `0xC0000005` is the FXC/runtime-WGSL path from 403a7b77 or something else.

## Testing

No .NET SDK on the machine I authored this on, so this leans on CI (builds + tests on `windows-latest` and `macos-15`). Changes are confined to three files and add no new dependencies.

## Note

#(follow-up) removes the warm capture host entirely, which deletes `CaptureProcessHost.cs` and two of the three call sites touched here. These are meant to merge in order — this one first, so the logging improvement lands independently of that decision and applies to the one-shot path that survives it.