### PR TITLE
Round picked-window selections to the window's OS corner radius

### DIFF
--- a/clowd_capture/CAPTURE_PROTOCOL.md
+++ b/clowd_capture/CAPTURE_PROTOCOL.md
@@ -42,6 +42,7 @@ flags that differ (`CaptureArguments.Build`).
 | `--no-peek` | flag | peek on | Disable obstructed-window peek-through capture. |
 | `--peek-threshold` | 0.0–1.0 | `0.80` | Max obstructed fraction before a window is dropped from hit-testing. |
 | `--no-cursor` | flag | cursor on | Start with the captured cursor hidden (user toggles with `M`). |
+| `--no-rounded-corners` | flag | rounded on | Keep window selections square. By default a selection made by picking a window (hover + click, `W`, `--capture-mode window`) takes on that window's OS corner radius: the dashed border is drawn rounded and the corner pixels are transparent in the copied / saved image and in `cropped.png`. Dragged, moved or resized selections are always square. The radius is asked of the OS where possible (DWM on Windows 11; the window server's own corner mask on macOS) with a per-version table as fallback — `src/system/corners.rs`. `desktop.png` is never rounded. |
 | `--no-upload` | flag | UPLOAD shown | Hide the UPLOAD button — in the capture strip *and* the OCR strip — and drop its `U` accelerator. |
 | `--no-scroll-capture` | flag | SCROLL shown | Hide the SCROLL button and drop its `L` accelerator. Windows-only button; the flag parses everywhere. |
 | `--no-ocr` | flag | OCR shown | Hide the OCR button and drop its `O` accelerator. The button is the only way into OCR mode, so this also removes the OCR strip. |
@@ -72,7 +73,7 @@ File contents:
 | File | Contents |
 |---|---|
 | `desktop.png` | Full virtual-desktop bitmap, locked peek window composited, never the cursor (the editor toggles cursor visibility itself). |
-| `cropped.png` | Preview of the selection, peek composited; cursor composited only if visible to the user. For VIDEO: no peek compositing (the recording shows real obstructions). |
+| `cropped.png` | Preview of the selection, peek composited; cursor composited only if visible to the user; corners transparent when the selection is a picked window and rounded corners are on (`--no-rounded-corners`). For VIDEO: no peek compositing (the recording shows real obstructions) and never rounded. |
 | `cursor.png` | Desktop crop at the cursor rect with the cursor composited. Absent when no cursor was captured or the OS reported it hidden. |
 | `session.json` | Session metadata (§1.3). |
 | `ocr.txt` | The text recognized in the selection, UTF-8 without BOM, lines separated by `\n`. Present only with the `ocr-upload` marker; the shell reads it, uploads it as a text paste, and deletes the directory. |
@@ -134,6 +135,7 @@ Rects serialize as `{ "X": …, "Y": …, "Width": …, "Height": … }`
 | `CursorPosition` | rect, optional | Cursor rect relative to the desktop bitmap origin |
 | `CroppedRect` | rect | Selection relative to the desktop bitmap origin |
 | `OriginalBounds` | rect | Selection in virtual-desktop coordinates |
+| `CornerRadius` | number, optional | Corner radius in pixels of `CroppedRect` that the capture's corners are rounded with — the OS corner radius of the window the user picked (see `--no-rounded-corners`). Present only when non-zero; absent = square. `cropped.png` already has these corners transparent; `desktop.png` does not, so the editor applies the radius itself when it crops (its image graphic's `CornerRadius`, which the user can then edit). |
 
 ### 1.4 Exit codes
 

--- a/clowd_capture/shaders/desktop.wgsl
+++ b/clowd_capture/shaders/desktop.wgsl
@@ -71,7 +71,23 @@ struct Uniforms {
     //                the monochrome page when OCR starts and colour
     //                returns with the retract.
     ocr_params:       vec4<f32>,
+    // selection_shape.x = corner radius of the selection in window-local
+    //                px (through the same zoom transform as
+    //                selection_rect). 0 = square: the border takes the
+    //                original pixel-exact integer-slab path below. > 0
+    //                only for a picked window, whose OS corner radius it
+    //                is; the border is then drawn as an anti-aliased
+    //                rounded rect whose dashes run along the curved
+    //                perimeter, and the rect's own corners — outside the
+    //                curve — get the faded "outside" treatment, matching
+    //                the transparent corners of the copied / saved image.
+    // selection_shape.y = dash period in physical px for this frame, or 0
+    //                for the nominal 32 × DPI-step. See dash_period().
+    selection_shape:  vec4<f32>,
 };
+
+const PI: f32 = 3.14159265;
+const HALF_PI: f32 = 1.57079633;
 
 @group(0) @binding(0) var<uniform> u: Uniforms;
 @group(0) @binding(1) var desktop_tex: texture_2d<f32>;
@@ -117,6 +133,106 @@ fn srgb_to_linear(c: vec3<f32>) -> vec3<f32> {
 
 fn linear_to_srgb(c: vec3<f32>) -> vec3<f32> {
     return sqrt(c);
+}
+
+// The colour of a pixel OUTSIDE the selection: the desktop crushed to
+// darkened grayscale by `fade`. Bit-exact passthrough at fade = 0 (see
+// the comment at the end of fs_main — this is that code, shared with the
+// rounded-corner border path, which needs it mid-function).
+fn fade_outside(base: vec4<f32>, fade: f32) -> vec4<f32> {
+    if (fade == 0.0) {
+        return base;
+    }
+    let linear = srgb_to_linear(base.rgb);
+    let luma = dot(linear, vec3<f32>(0.2126, 0.7152, 0.0722)) * 0.42;
+    let gray_linear = vec3<f32>(luma);
+    let out_linear = mix(linear, gray_linear, fade);
+    return vec4<f32>(linear_to_srgb(out_linear), 1.0);
+}
+
+// The colour of a pixel INSIDE the selection: the desktop untouched, or
+// desaturated + dimmed while OCR mode is active (see the in_fill comment
+// below for the reasoning; this is that code, shared the same way).
+fn selection_fill(base: vec4<f32>) -> vec4<f32> {
+    let dim = clamp(u.ocr_params.x, 0.0, 1.0);
+    let gray = clamp(u.ocr_params.z, 0.0, 1.0);
+    if (dim <= 0.0 && gray <= 0.0) {
+        return base;
+    }
+    let lin = srgb_to_linear(base.rgb);
+    let luma = vec3<f32>(dot(lin, vec3<f32>(0.2126, 0.7152, 0.0722)));
+    let desat = linear_to_srgb(mix(lin, luma, gray));
+    return vec4<f32>(desat * (1.0 - dim), 1.0);
+}
+
+// The marching-ants dash period for this frame: the CPU's (render/
+// desktop.rs `dash_period`) when it sent one — nominal 32 px × DPI step,
+// snapped to the border's perimeter so the pattern wraps seamlessly,
+// except mid-drag — else the nominal period.
+fn dash_period(sel_step: i32) -> f32 {
+    let sent = u.selection_shape.y;
+    return select(32.0 * f32(sel_step), sent, sent > 0.0);
+}
+
+// Signed distance from pixel centre `p` to the rounded rect
+// [rmin, rmax] with corner radius `r`: negative inside, zero on the
+// curve, positive outside. The classic Inigo Quilez rounded-box SDF.
+fn rounded_rect_sdf(p: vec2<f32>, rmin: vec2<f32>, rmax: vec2<f32>, r: f32) -> f32 {
+    let half_size = (rmax - rmin) * 0.5;
+    let centre = rmin + half_size;
+    let q = abs(p - centre) - (half_size - vec2<f32>(r, r));
+    return length(max(q, vec2<f32>(0.0, 0.0))) + min(max(q.x, q.y), 0.0) - r;
+}
+
+// Arc length of the clockwise walk around a rounded rect [rmin, rmax]
+// with radius `r`, starting at the top of the LEFT edge — where the
+// straight left side meets the top-left curve — so the seam where the
+// dash pattern wraps (the perimeter is never a whole number of periods)
+// sits just before that curve rather than breaking the curve itself:
+// TL arc → top → TR arc → right → BR arc → bottom → BL arc → left.
+// Evaluated for a pixel by which straight edge or corner quadrant it
+// falls in, so every pixel across the border's thickness gets (near) the
+// same value and a dash reads as a solid stripe across the stroke — the
+// same property the integer path's `arc` has.
+fn rounded_rect_arc(p: vec2<f32>, rmin: vec2<f32>, rmax: vec2<f32>, r: f32) -> f32 {
+    let lt = (rmax.x - rmin.x) - 2.0 * r;   // straight top / bottom length
+    let ls = (rmax.y - rmin.y) - 2.0 * r;   // straight left / right length
+    let qa = HALF_PI * r;                   // one quarter arc
+    let near_left   = p.x < rmin.x + r;
+    let near_right  = p.x > rmax.x - r;
+    let near_top    = p.y < rmin.y + r;
+    let near_bottom = p.y > rmax.y - r;
+    if (near_top && near_left) {
+        // phi in (-PI, -PI/2): from the left edge's end round to the top's start.
+        let phi = atan2(p.y - (rmin.y + r), p.x - (rmin.x + r));
+        return (phi + PI) * r;
+    }
+    if (near_top && near_right) {
+        // phi in (-PI/2, 0).
+        let phi = atan2(p.y - (rmin.y + r), p.x - (rmax.x - r));
+        return qa + lt + (phi + HALF_PI) * r;
+    }
+    if (near_bottom && near_right) {
+        // phi in (0, PI/2).
+        let phi = atan2(p.y - (rmax.y - r), p.x - (rmax.x - r));
+        return 2.0 * qa + lt + ls + phi * r;
+    }
+    if (near_bottom && near_left) {
+        // phi in (PI/2, PI).
+        let phi = atan2(p.y - (rmax.y - r), p.x - (rmin.x + r));
+        return 3.0 * qa + 2.0 * lt + ls + (phi - HALF_PI) * r;
+    }
+    if (near_top) {
+        return qa + (p.x - (rmin.x + r));
+    }
+    if (near_right) {
+        return 2.0 * qa + lt + (p.y - (rmin.y + r));
+    }
+    if (near_bottom) {
+        return 3.0 * qa + lt + ls + ((rmax.x - r) - p.x);
+    }
+    // left
+    return 4.0 * qa + 2.0 * lt + ls + ((rmax.y - r) - p.y);
 }
 
 @fragment
@@ -335,6 +451,42 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
             }
         }
 
+        // Rounded selection (a picked window): the border is the same
+        // 2*half stroke straddling the rect's edge, but run around a
+        // rounded rect and anti-aliased over one pixel, with the dash
+        // phase measured along the curved perimeter. The rect's square
+        // corners lie OUTSIDE the curve and take the faded treatment —
+        // exactly the pixels the copied image leaves transparent. The
+        // integer path below stays byte-for-byte for radius 0.
+        let radius = u.selection_shape.x;
+        if (radius > 0.0) {
+            let fpos = in.pos.xy;
+            let rmin = vec2<f32>(f32(sx), f32(sy));
+            let rmax = vec2<f32>(f32(sz), f32(sw));
+            // A radius past half the shorter side would invert the SDF;
+            // the window server clamps the same way (stadium / circle).
+            let r = min(radius, min(rmax.x - rmin.x, rmax.y - rmin.y) * 0.5);
+            let d = rounded_rect_sdf(fpos, rmin, rmax, r);
+            let half_f = f32(half);
+            // Straight edges at integer coordinates land pixel centres at
+            // half-integer distances, so these two coverages are exactly
+            // 0 or 1 there and reproduce the integer path's classification;
+            // only the curves see fractional values.
+            let border_a = clamp(half_f + 0.5 - abs(d), 0.0, 1.0);
+            let inside_a = clamp(-(d + half_f) + 0.5, 0.0, 1.0);
+            var col = mix(fade_outside(base, fade), selection_fill(base), inside_a);
+            if (border_a > 0.0) {
+                let period = dash_period(sel_step);
+                let half_period = period * 0.5;
+                let t_offset = u.selection_params.x * period;
+                let raw = rounded_rect_arc(fpos, rmin, rmax, r) - t_offset;
+                let phase = raw - period * floor(raw / period);
+                let dash = select(vec4<f32>(1.0, 1.0, 1.0, 1.0), u.accent_color, phase < half_period);
+                col = mix(col, dash, border_a * fade);
+            }
+            return col;
+        }
+
         // Classify the pixel into one of the four border slabs.
         // Each slab is 2*half px thick. Top/bottom claim the
         // (2*half)×(2*half) corner squares so the left/right slabs
@@ -389,8 +541,11 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
             // units × 2 DIPs stroke width at
             // DxScreenCapture.cpp:638-645. The animation completes
             // one full cycle per second. WGSL has no f32 `%`, so
-            // fold with floor() instead.
-            let period = 32.0 * f32(sel_step);
+            // fold with floor() instead. The period comes from the
+            // CPU — snapped to the perimeter so the pattern wraps
+            // without a seam, nominal only while a drag is in progress
+            // (see render/desktop.rs).
+            let period = dash_period(sel_step);
             let half_period = period * 0.5;
             let t_offset = u.selection_params.x * period;
             let raw = f32(arc) - t_offset;

--- a/clowd_capture/shaders/peek.wgsl
+++ b/clowd_capture/shaders/peek.wgsl
@@ -16,6 +16,12 @@ struct PeekUniforms {
     // desktop snapshot instead would show the OBSCURING window (the
     // snapshot has no peek composite). All zero outside OCR mode.
     ocr_params:     vec4<f32>,
+    // (corner_radius, 0, 0, 0) — the selection's corner radius in
+    // monitor-local pixels, same value as the desktop pass's
+    // selection_shape.x. 0 = square. When > 0 the quad stops at the same
+    // rounded inner edge the desktop pass draws its border around, so the
+    // peeked window never paints over the corner the border curves past.
+    selection_shape: vec4<f32>,
     // Up to 16 obstruction rects in monitor-local pixels.
     obstruction_rects: array<vec4<f32>, 16>,
 };
@@ -104,6 +110,23 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
     if (px.x < inner_left || px.x > inner_right ||
         px.y < inner_top  || px.y > inner_bottom) {
         discard;
+    }
+
+    // Rounded selection: also stop at the curve. Same SDF and the same
+    // "inside" threshold as desktop.wgsl's inside_a >= 0.5, so the peek
+    // and the border agree on every pixel of the corner.
+    let radius = u.selection_shape.x;
+    if (radius > 0.0) {
+        let rmin = vec2<f32>(sr.x, sr.y);
+        let rmax = vec2<f32>(sr.z, sr.w);
+        let r = min(radius, min(rmax.x - rmin.x, rmax.y - rmin.y) * 0.5);
+        let half_size = (rmax - rmin) * 0.5;
+        let centre = rmin + half_size;
+        let q = abs(in.pos.xy - centre) - (half_size - vec2<f32>(r, r));
+        let d = length(max(q, vec2<f32>(0.0, 0.0))) + min(max(q.x, q.y), 0.0) - r;
+        if (d > -f32(half)) {
+            discard;
+        }
     }
 
     // ── Preserve resize handles (drawn by desktop shader) ─────────

--- a/clowd_capture/shaders/ui_lift.wgsl
+++ b/clowd_capture/shaders/ui_lift.wgsl
@@ -25,12 +25,14 @@ struct Uniforms {
 struct Instance {
     // min_x, min_y, max_x, max_y in window-local physical pixels.
     @location(0) dest_px: vec4<f32>,
-    // (alpha, band_centre, sweep σ, unused). Band centre is in quad-space
-    // v (0 = top, 1 = bottom); it travels top → bottom and deliberately
-    // OVERSHOOTS both edges — see anim::sweep_band — so the looping wrap
-    // happens with the band fully invisible. σ is supplied by the CPU
-    // (anim::SWEEP_SIGMA) so the falloff and the overshoot can never
-    // disagree.
+    // (alpha, band_centre, sweep σ, corner_radius). Band centre is in
+    // quad-space v (0 = top, 1 = bottom); it travels top → bottom and
+    // deliberately OVERSHOOTS both edges — see anim::sweep_band — so the
+    // looping wrap happens with the band fully invisible. σ is supplied by
+    // the CPU (anim::SWEEP_SIGMA) so the falloff and the overshoot can
+    // never disagree. corner_radius is the selection's (window-local px,
+    // 0 = square): the band is clipped to that rounded rect so it stays
+    // inside the curved border a picked window is drawn with.
     @location(1) params: vec4<f32>,
     // Band colour (straight alpha 1.0; the fragment premultiplies).
     @location(2) tint: vec4<f32>,
@@ -41,6 +43,8 @@ struct VsOut {
     @location(0) corner: vec2<f32>,
     @location(1) params: vec4<f32>,
     @location(2) tint: vec4<f32>,
+    // The instance rect, carried to the fragment for the rounded clip.
+    @location(3) dest_px: vec4<f32>,
 };
 
 @vertex
@@ -65,6 +69,7 @@ fn vs_main(@builtin(vertex_index) vi: u32, inst: Instance) -> VsOut {
     out.corner = c;
     out.params = inst.params;
     out.tint = inst.tint;
+    out.dest_px = inst.dest_px;
     return out;
 }
 
@@ -79,6 +84,20 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
     let dv = in.corner.y - band;
     let sigma = max(in.params.z, 1e-3);
     let fall = exp(-(dv * dv) / (2.0 * sigma * sigma));
-    let a = alpha * fall;
+    var a = alpha * fall;
+
+    // Rounded selection: clip to the curve (same rounded-box SDF as
+    // desktop.wgsl, 1 px anti-aliased at pixel centres). Square selections
+    // (radius 0) skip this and keep the full quad.
+    let radius = in.params.w;
+    if (radius > 0.0) {
+        let rmin = in.dest_px.xy;
+        let rmax = in.dest_px.zw;
+        let half_size = (rmax - rmin) * 0.5;
+        let r = min(radius, min(half_size.x, half_size.y));
+        let q = abs(in.pos.xy - (rmin + half_size)) - (half_size - vec2<f32>(r, r));
+        let d = length(max(q, vec2<f32>(0.0, 0.0))) + min(max(q.x, q.y), 0.0) - r;
+        a = a * clamp(0.5 - d, 0.0, 1.0);
+    }
     return vec4<f32>(in.tint.rgb * a, a);
 }

--- a/clowd_capture/src/app.rs
+++ b/clowd_capture/src/app.rs
@@ -26,7 +26,7 @@ use crate::session_output::{
 };
 use crate::settings::{CaptureMode, CapturerSettings};
 use crate::sync::{Latch, VisibleLatch};
-use crate::system::{CapturedDesktop, MonitorInfo, SystemInterop, WindowPeekImage, WindowWalker};
+use crate::system::{CapturedDesktop, MonitorInfo, SystemInterop, WindowPeekImage, WindowTarget, WindowWalker};
 use crate::telemetry::startup::StartupTimings;
 use crate::ui::command::Command;
 use crate::ui::components::panel;
@@ -187,7 +187,14 @@ pub enum CycleAction {
 
 fn broadcast_mouse_state(windows: &WindowSet, input: &InteractionState) {
     for h in windows.values() {
-        h.update_mouse_state(input.virtual_cursor, input.zoom, input.selection, input.captured);
+        h.update_mouse_state(
+            input.virtual_cursor,
+            input.zoom,
+            input.selection,
+            input.selection_radius,
+            input.mouse_down,
+            input.captured,
+        );
     }
 }
 
@@ -467,6 +474,7 @@ fn broadcast_ui_state(windows: &WindowSet, monitors: &[MonitorInfo], ui_monitors
     let state = Arc::new(build_ui_shared_state(UiStateBuildInput {
         monitors: ui_monitors.clone(),
         selection: cycle.input.selection,
+        selection_radius: cycle.input.selection_radius,
         captured: cycle.input.captured,
         mouse_down: cycle.input.mouse_down,
         dragging: cycle.input.dragging,
@@ -608,6 +616,7 @@ impl App {
                 mouse_down_dpi: 1.0,
                 dragging: false,
                 selection: None,
+                selection_radius: 0.0,
                 captured: false,
                 hittest: Hittest::Outside,
                 drag_mode: None,
@@ -733,7 +742,9 @@ impl App {
                     cycle.input.virtual_cursor.x.round() as i32,
                     cycle.input.virtual_cursor.y.round() as i32,
                 );
-                cycle.input.selection = w.hit_test(pt);
+                cycle
+                    .input
+                    .set_hover_target(w.hit_test_target(pt));
                 cycle.walker = Some(w);
             }
         }
@@ -1006,15 +1017,25 @@ impl App {
         broadcast_ui_state(&self.windows, &self.monitors, &self.ui_monitors, cycle);
     }
 
+    /// Capture a plain rect — a monitor, the whole desktop: square corners.
     fn finalise_selection(&mut self, rect: ScreenRect, event_loop: &ActiveEventLoop, window_id: WindowId) {
-        self.finalise_selection_inner(rect, event_loop, window_id, false);
+        self.finalise_selection_inner(rect, 0.0, event_loop, window_id, false);
     }
 
-    fn finalise_selection_with_peek(&mut self, rect: ScreenRect, event_loop: &ActiveEventLoop, window_id: WindowId) {
-        self.finalise_selection_inner(rect, event_loop, window_id, true);
+    /// Capture a walker window: its rect AND its corner radius, with the
+    /// hovered peek (if any) locked in.
+    fn finalise_window_selection_with_peek(&mut self, target: WindowTarget, event_loop: &ActiveEventLoop, window_id: WindowId) {
+        self.finalise_selection_inner(target.rect, target.corner_radius, event_loop, window_id, true);
     }
 
-    fn finalise_selection_inner(&mut self, rect: ScreenRect, event_loop: &ActiveEventLoop, window_id: WindowId, lock_peek: bool) {
+    fn finalise_selection_inner(
+        &mut self,
+        rect: ScreenRect,
+        corner_radius: f32,
+        event_loop: &ActiveEventLoop,
+        window_id: WindowId,
+        lock_peek: bool,
+    ) {
         let Some(cycle) = self.cycle.as_mut() else {
             return;
         };
@@ -1032,7 +1053,7 @@ impl App {
         }
         cycle.input.peek_suspended = true;
 
-        let effects = InteractionController::finalize_selection(&mut cycle.input, rect, &self.monitors);
+        let effects = InteractionController::finalize_selection(&mut cycle.input, rect, corner_radius, &self.monitors);
         self.apply_interaction_effects(effects, Some(window_id));
 
         // Keyboard / preselect captured-transition site (DESIGN §3.3).
@@ -1054,18 +1075,21 @@ impl App {
         }
     }
 
-    /// Target rect for a `--capture-mode screen|window` pre-selection.
-    /// `Screen` is the monitor under the cursor; `Window` is the foreground
-    /// window, falling back to the active screen when no foreground window is
-    /// available. `Region` never pre-selects.
-    fn preselect_rect(&self, mode: CaptureMode) -> Option<ScreenRect> {
+    /// Target for a `--capture-mode screen|window` pre-selection. `Screen`
+    /// is the monitor under the cursor (square); `Window` is the foreground
+    /// window with its corner radius, falling back to the active screen when
+    /// no foreground window is available. `Region` never pre-selects.
+    fn preselect_target(&self, mode: CaptureMode) -> Option<WindowTarget> {
         let cycle = self.cycle.as_ref()?;
         let active_screen = || {
             let pt = to_screen_point(cycle.input.virtual_cursor);
             self.monitors
                 .iter()
                 .find(|m| m.bounds.contains(pt))
-                .map(|m| m.bounds)
+                .map(|m| WindowTarget {
+                    rect: m.bounds,
+                    corner_radius: 0.0,
+                })
         };
         match mode {
             CaptureMode::Region => None,
@@ -1073,7 +1097,7 @@ impl App {
             CaptureMode::Window => cycle
                 .walker
                 .as_ref()
-                .and_then(|w| w.foreground_capture_rect())
+                .and_then(|w| w.foreground_capture_target())
                 .or_else(active_screen),
         }
     }
@@ -1101,10 +1125,10 @@ impl App {
             return;
         };
 
-        match self.preselect_rect(mode) {
-            Some(rect) => {
-                log::info!("--capture-mode {:?}: pre-selecting {:?}", mode, rect);
-                self.finalise_selection(rect, event_loop, window_id);
+        match self.preselect_target(mode) {
+            Some(target) => {
+                log::info!("--capture-mode {:?}: pre-selecting {:?}", mode, target);
+                self.finalise_selection_inner(target.rect, target.corner_radius, event_loop, window_id, false);
             }
             None => log::info!("--capture-mode {:?}: no target found; leaving free selection", mode),
         }
@@ -1130,10 +1154,11 @@ impl App {
             cycle.input.virtual_cursor.x.round() as i32,
             cycle.input.virtual_cursor.y.round() as i32,
         );
-        cycle.input.selection = cycle
+        let hover = cycle
             .walker
             .as_ref()
-            .and_then(|w| w.hit_test(pt));
+            .and_then(|w| w.hit_test_target(pt));
+        cycle.input.set_hover_target(hover);
 
         broadcast_mouse_state(&self.windows, &cycle.input);
 
@@ -1264,7 +1289,9 @@ impl App {
             Command::Copy => {
                 hide_overlay_for_action(&self.windows);
                 let result = match (cycle.input.selection, cycle.desktop_buffer.as_deref()) {
-                    (Some(sel), Some(buf)) => copy_to_clipboard_with_peek(sel, buf, active_peek_image, cursor, cursor_visible),
+                    (Some(sel), Some(buf)) => {
+                        copy_to_clipboard_with_peek(sel, cycle.input.selection_radius, buf, active_peek_image, cursor, cursor_visible)
+                    }
                     _ => ActionResult::Failed("No selection or buffer".into()),
                 };
                 match result {
@@ -1284,7 +1311,9 @@ impl App {
                 hide_overlay_for_action(&self.windows);
                 let result = match (cycle.input.selection, cycle.desktop_buffer.as_deref()) {
                     (Some(sel), Some(buf)) => match self.windows.get(&window_id) {
-                        Some(handle) => handle.save_to_file_with_peek(sel, buf, active_peek_image, cursor, cursor_visible),
+                        Some(handle) => {
+                            handle.save_to_file_with_peek(sel, cycle.input.selection_radius, buf, active_peek_image, cursor, cursor_visible)
+                        }
                         None => ActionResult::Failed("No active window".into()),
                     },
                     _ => ActionResult::Failed("No selection or buffer".into()),
@@ -1318,7 +1347,15 @@ impl App {
                 };
                 hide_overlay_for_action(&self.windows);
                 let result = match (cycle.input.selection, cycle.desktop_buffer.as_deref()) {
-                    (Some(sel), Some(buf)) => write_session(&session_dir, sel, buf, active_peek_image, cursor_visible, action),
+                    (Some(sel), Some(buf)) => write_session(
+                        &session_dir,
+                        sel,
+                        cycle.input.selection_radius,
+                        buf,
+                        active_peek_image,
+                        cursor_visible,
+                        action,
+                    ),
                     _ => ActionResult::Failed("No selection or buffer".into()),
                 };
                 match result {
@@ -2045,12 +2082,12 @@ impl ApplicationHandler for App {
                                     cycle.input.virtual_cursor.x.round() as i32,
                                     cycle.input.virtual_cursor.y.round() as i32,
                                 );
-                                if let Some(rect) = cycle
+                                if let Some(target) = cycle
                                     .walker
                                     .as_ref()
-                                    .and_then(|w| w.hit_test(pt))
+                                    .and_then(|w| w.hit_test_target(pt))
                                 {
-                                    self.finalise_selection_with_peek(rect, event_loop, id);
+                                    self.finalise_window_selection_with_peek(target, event_loop, id);
                                 }
                             }
                             'f' => {
@@ -2117,10 +2154,11 @@ impl ApplicationHandler for App {
                         cycle.input.virtual_cursor.x.round() as i32,
                         cycle.input.virtual_cursor.y.round() as i32,
                     );
-                    cycle.input.selection = cycle
+                    let hover = cycle
                         .walker
                         .as_ref()
-                        .and_then(|w| w.hit_test(pt));
+                        .and_then(|w| w.hit_test_target(pt));
+                    cycle.input.set_hover_target(hover);
                 }
 
                 if cycle.input.mouse_down && !cycle.input.captured {
@@ -2139,7 +2177,11 @@ impl ApplicationHandler for App {
                             }
                         }
                         if cycle.input.dragging {
+                            // A dragged rect is the user's own shape, not a
+                            // window's: square however round the window the
+                            // drag started over.
                             cycle.input.selection = psel;
+                            cycle.input.selection_radius = 0.0;
                         }
                     }
                 }
@@ -2159,6 +2201,9 @@ impl ApplicationHandler for App {
                             DragMode::Resize(handle) => Some(resize_with_clamp(anchor, handle, cur_x, cur_y, self.vd_bounds)),
                         };
                         cycle.input.selection = new_sel;
+                        // Moved or resized, the rect no longer outlines the
+                        // window it came from; its corners go square.
+                        cycle.input.selection_radius = 0.0;
                         // No broadcast here — the unconditional
                         // broadcast_ui_state at the end of CursorMoved
                         // covers this path.
@@ -2462,6 +2507,7 @@ mod tests {
             mouse_down_dpi: 1.0,
             dragging: false,
             selection: None,
+            selection_radius: 0.0,
             captured: false,
             hittest: Hittest::Outside,
             drag_mode: None,

--- a/clowd_capture/src/capture/session.rs
+++ b/clowd_capture/src/capture/session.rs
@@ -88,6 +88,7 @@ impl CaptureSession {
             render_msg_txs,
             settings.obscured_window_peek_enabled,
             settings.obscured_window_detection_threshold,
+            settings.rounded_window_corners,
             timings.clone(),
         );
 
@@ -310,6 +311,7 @@ fn spawn_walker_job(
     render_msg_txs: Vec<mpsc::Sender<RenderMsg>>,
     peek_enabled: bool,
     visibility_threshold: f32,
+    rounded_corners: bool,
     timings: Arc<StartupTimings>,
 ) -> (WalkerLatch, PeekImagesLatch) {
     let walker_latch = Arc::new(Latch::new());
@@ -325,13 +327,21 @@ fn spawn_walker_job(
                 .background
                 .walker_start
                 .set_once(timings.t_start.elapsed());
-            let walker = SystemInterop::snapshot_windows(&monitors, visibility_threshold);
+            let walker = Arc::new(SystemInterop::snapshot_windows(&monitors, visibility_threshold, rounded_corners));
             let obstructed = if peek_enabled { walker.obstructed_windows() } else { Vec::new() };
-            latch.set(Arc::new(walker));
+            latch.set(walker.clone());
             timings
                 .background
                 .walker
                 .set_once(timings.t_start.elapsed());
+
+            // Only now, with hover hit-testing already live off the
+            // published snapshot: ask the OS for each window's real corner
+            // radius where that is a per-window round-trip (macOS; a no-op
+            // on Windows, which resolved it during the snapshot). Ahead of
+            // the peek captures because it touches every hover, not only
+            // the obstructed windows.
+            walker.probe_corner_radii(&monitors);
 
             if !peek_enabled {
                 return;

--- a/clowd_capture/src/capture_output.rs
+++ b/clowd_capture/src/capture_output.rs
@@ -3,7 +3,9 @@ use std::time::Duration;
 
 use winit::window::Window;
 
-use crate::image_extract::{composite_cursor_rgba, extract_selection_rgba, extract_selection_rgba_with_peek};
+use crate::image_extract::{
+    apply_rounded_corners, composite_cursor_rgba, corners_to_round, extract_selection_rgba, extract_selection_rgba_with_peek,
+};
 use crate::system::{CapturedCursor, CapturedDesktop, WindowPeekImage};
 use clowd_rust_core::geometry::ScreenRect;
 
@@ -17,27 +19,52 @@ pub enum ActionResult {
     Failed(String),
 }
 
-/// Copy the selected region to the clipboard.
-pub fn copy_to_clipboard_with_peek(
+/// Extract the selection as straight-alpha RGBA with the peek composited,
+/// the cursor drawn if visible, and — for a picked window — its OS corner
+/// radius cut into the alpha (`corner_radius` > 0, see
+/// `InteractionState::selection_radius`). Shared by copy and save so the
+/// two can never disagree about what "the image" is.
+pub fn extract_output_image(
     selection: ScreenRect,
+    corner_radius: f32,
     buffer: &CapturedDesktop,
     peek: Option<&WindowPeekImage>,
     cursor: Option<&CapturedCursor>,
     cursor_visible: bool,
-) -> ActionResult {
-    let extracted = match peek {
+) -> Option<(Vec<u8>, u32, u32)> {
+    let (mut rgba, width, height) = match peek {
         Some(p) => extract_selection_rgba_with_peek(selection, buffer, p),
         None => extract_selection_rgba(selection, buffer),
-    };
-    let Some((mut rgba, width, height)) = extracted else {
-        log::warn!("copy: no selection or failed to extract");
-        return ActionResult::Failed("No selection to copy".to_string());
-    };
+    }?;
     if cursor_visible {
         if let Some(cur) = cursor {
             composite_cursor_rgba(&mut rgba, width, height, selection, cur);
         }
     }
+    if corner_radius > 0.0 {
+        // The extract clamps to the desktop bitmap; a corner that was cut
+        // off by that clamp is not a window corner and stays square.
+        let clamped = selection
+            .intersection(&buffer.bounds)
+            .unwrap_or(selection);
+        apply_rounded_corners(&mut rgba, width, height, corner_radius, corners_to_round(selection, clamped));
+    }
+    Some((rgba, width, height))
+}
+
+/// Copy the selected region to the clipboard.
+pub fn copy_to_clipboard_with_peek(
+    selection: ScreenRect,
+    corner_radius: f32,
+    buffer: &CapturedDesktop,
+    peek: Option<&WindowPeekImage>,
+    cursor: Option<&CapturedCursor>,
+    cursor_visible: bool,
+) -> ActionResult {
+    let Some((rgba, width, height)) = extract_output_image(selection, corner_radius, buffer, peek, cursor, cursor_visible) else {
+        log::warn!("copy: no selection or failed to extract");
+        return ActionResult::Failed("No selection to copy".to_string());
+    };
 
     match set_clipboard_image(&rgba, width as usize, height as usize) {
         Ok(()) => {
@@ -169,25 +196,17 @@ where
 /// Save the selected region to a file via save dialog.
 pub fn save_to_file_with_peek(
     selection: ScreenRect,
+    corner_radius: f32,
     buffer: &CapturedDesktop,
     peek: Option<&WindowPeekImage>,
     cursor: Option<&CapturedCursor>,
     cursor_visible: bool,
     window: &Window,
 ) -> ActionResult {
-    let extracted = match peek {
-        Some(p) => extract_selection_rgba_with_peek(selection, buffer, p),
-        None => extract_selection_rgba(selection, buffer),
-    };
-    let Some((mut rgba, width, height)) = extracted else {
+    let Some((rgba, width, height)) = extract_output_image(selection, corner_radius, buffer, peek, cursor, cursor_visible) else {
         log::warn!("save: no selection or failed to extract");
         return ActionResult::Failed("No selection to save".to_string());
     };
-    if cursor_visible {
-        if let Some(cur) = cursor {
-            composite_cursor_rgba(&mut rgba, width, height, selection, cur);
-        }
-    }
 
     let path = rfd::FileDialog::new()
         .add_filter("PNG Image", &["png"])

--- a/clowd_capture/src/gpu/desktop.rs
+++ b/clowd_capture/src/gpu/desktop.rs
@@ -27,6 +27,18 @@ pub struct WindowUniforms {
     /// y = OCR-mode-active flag (suppresses the resize handles: they must
     /// not draw over lifted text), z/w spare.
     pub ocr_params: [f32; 4],
+    /// x = the selection's corner radius in window-local physical px
+    /// (already through the magnifier zoom, like `selection_rect`); 0 =
+    /// square, which keeps the shader on its original integer-slab border
+    /// path. Non-zero only for a picked window — see
+    /// `InteractionState::selection_radius`.
+    /// y = the marching-ants dash period in physical px for this frame —
+    /// see `render::desktop::dash_period`: the nominal 32 px × DPI step,
+    /// snapped so the border's perimeter holds a whole number of dashes
+    /// (no seam where the pattern wraps) except while the selection is
+    /// being dragged, when the snap would re-phase every frame. 0 = let
+    /// the shader use the nominal period. z/w spare.
+    pub selection_shape: [f32; 4],
 }
 
 pub const WINDOW_UNIFORMS_SIZE: u64 = std::mem::size_of::<WindowUniforms>() as u64;

--- a/clowd_capture/src/gpu/peek.rs
+++ b/clowd_capture/src/gpu/peek.rs
@@ -16,6 +16,12 @@ pub struct PeekUniforms {
     /// was supposed to be monochrome. All zero outside OCR mode — the
     /// non-OCR peek path is byte-identical to before.
     pub ocr_params: [f32; 4],
+    /// x = the selection's corner radius in monitor-local px (0 = square),
+    /// same value and space as the desktop pass's `selection_shape.x`. The
+    /// peek quad covers the selection's interior, so it must stop at the
+    /// same rounded inner edge the desktop pass draws, or it would paint
+    /// the peeked window over the corner the border curves around.
+    pub selection_shape: [f32; 4],
     pub obstruction_rects: [[f32; 4]; 16],
 }
 

--- a/clowd_capture/src/image_extract.rs
+++ b/clowd_capture/src/image_extract.rs
@@ -251,6 +251,84 @@ pub fn extract_selection_bgra_with_peek(
     Some(result)
 }
 
+/// Which corners of the extracted image are real corners of the window
+/// the user picked — i.e. may be rounded. A selection that ran off the
+/// desktop bitmap was clamped (`clamped = selection ∩ bounds`); any corner
+/// touching a clamped edge is a cut, not a corner, and must stay square or
+/// the crop would bite into window content. Order: TL, TR, BL, BR.
+pub fn corners_to_round(selection: ScreenRect, clamped: ScreenRect) -> [bool; 4] {
+    let left = clamped.left() == selection.left();
+    let top = clamped.top() == selection.top();
+    let right = clamped.right() == selection.right();
+    let bottom = clamped.bottom() == selection.bottom();
+    [left && top, right && top, left && bottom, right && bottom]
+}
+
+/// Make the pixels outside a rounded-rect of radius `radius` (px)
+/// transparent in a straight-alpha RGBA buffer, so a window copied or saved
+/// from the capture has the same corner shape the OS drew it with instead
+/// of a few pixels of whatever sat behind it. `corners` (TL, TR, BL, BR)
+/// says which corners to round — see [`corners_to_round`]. The same 1-px
+/// anti-aliased signed-distance coverage the overlay draws the rounded
+/// border with; fully transparent pixels also have their colour zeroed so
+/// nothing leaks through viewers that ignore alpha.
+pub fn apply_rounded_corners(rgba: &mut [u8], width: u32, height: u32, radius: f32, corners: [bool; 4]) {
+    let (w, h) = (width as usize, height as usize);
+    if radius <= 0.0 || w == 0 || h == 0 || rgba.len() < w * h * 4 || !corners.iter().any(|c| *c) {
+        return;
+    }
+    // Clamp like the overlay does: a radius larger than half the shorter
+    // side degenerates into a stadium / circle rather than inverting.
+    let r = radius
+        .min(w as f32 * 0.5)
+        .min(h as f32 * 0.5);
+    let span = r.ceil() as usize;
+    // Only the `span`×`span` squares at the corners can change; every row
+    // and column between them is skipped untouched.
+    let in_corner_band = |i: usize, len: usize| i < span || i + span >= len;
+    for y in (0..h).filter(|&y| in_corner_band(y, h)) {
+        for x in (0..w).filter(|&x| in_corner_band(x, w)) {
+            shade_corner_pixel(rgba, w, h, x, y, r, corners);
+        }
+    }
+}
+
+/// Coverage of pixel (`x`, `y`) under the rounded rect, applied to its
+/// alpha. Pixels not in a rounded corner's quadrant are left alone.
+fn shade_corner_pixel(rgba: &mut [u8], w: usize, h: usize, x: usize, y: usize, r: f32, corners: [bool; 4]) {
+    let px = x as f32 + 0.5;
+    let py = y as f32 + 0.5;
+    let (wf, hf) = (w as f32, h as f32);
+    // Which corner's circle centre applies to this pixel, if any.
+    let centre = if px < r && py < r {
+        corners[0].then_some((r, r))
+    } else if px > wf - r && py < r {
+        corners[1].then_some((wf - r, r))
+    } else if px < r && py > hf - r {
+        corners[2].then_some((r, hf - r))
+    } else if px > wf - r && py > hf - r {
+        corners[3].then_some((wf - r, hf - r))
+    } else {
+        None
+    };
+    let Some((cx, cy)) = centre else {
+        return;
+    };
+    let d = ((px - cx).powi(2) + (py - cy).powi(2)).sqrt() - r;
+    let coverage = (0.5 - d).clamp(0.0, 1.0);
+    if coverage >= 1.0 {
+        return;
+    }
+    let i = (y * w + x) * 4;
+    let a = (rgba[i + 3] as f32 * coverage).round() as u8;
+    if a == 0 {
+        rgba[i] = 0;
+        rgba[i + 1] = 0;
+        rgba[i + 2] = 0;
+    }
+    rgba[i + 3] = a;
+}
+
 /// Composite the captured cursor onto an already-extracted RGBA buffer.
 /// `selection` is the region in virtual-desktop coords that `rgba` covers.
 ///
@@ -796,5 +874,92 @@ mod tests {
         composite_cursor_rgba(&mut rgba, 1, 1, selection, &cursor);
 
         assert_eq!(rgba, vec![100, 150, 200, 255]);
+    }
+
+    #[test]
+    fn corners_to_round_only_where_the_selection_was_not_clamped() {
+        let sel = ScreenRect::from_xy_size(0, 0, 100, 100);
+        assert_eq!(corners_to_round(sel, sel), [true, true, true, true]);
+        // Clamped on the right: the two right-hand corners are cuts.
+        let clamped_right = ScreenRect::from_exact(0, 0, 80, 100);
+        assert_eq!(corners_to_round(sel, clamped_right), [true, false, true, false]);
+        // Clamped top and left: only bottom-right survives.
+        let clamped_tl = ScreenRect::from_exact(10, 10, 100, 100);
+        assert_eq!(corners_to_round(sel, clamped_tl), [false, false, false, true]);
+    }
+
+    fn opaque(w: u32, h: u32) -> Vec<u8> {
+        let mut v = vec![0u8; (w * h * 4) as usize];
+        for px in v.chunks_exact_mut(4) {
+            px.copy_from_slice(&[10, 20, 30, 255]);
+        }
+        v
+    }
+
+    fn alpha_at(buf: &[u8], w: u32, x: u32, y: u32) -> u8 {
+        buf[((y * w + x) * 4 + 3) as usize]
+    }
+
+    #[test]
+    fn rounded_corners_clear_the_corner_pixels_and_leave_the_rest() {
+        let (w, h) = (40u32, 30u32);
+        let mut buf = opaque(w, h);
+        apply_rounded_corners(&mut buf, w, h, 8.0, [true; 4]);
+        // The very corner pixels are fully transparent, colour zeroed.
+        for (x, y) in [(0, 0), (w - 1, 0), (0, h - 1), (w - 1, h - 1)] {
+            let i = ((y * w + x) * 4) as usize;
+            assert_eq!(&buf[i..i + 4], &[0, 0, 0, 0], "corner ({x},{y})");
+        }
+        // Straight edges away from the corners are untouched.
+        assert_eq!(alpha_at(&buf, w, 20, 0), 255);
+        assert_eq!(alpha_at(&buf, w, 0, 15), 255);
+        assert_eq!(alpha_at(&buf, w, w - 1, 15), 255);
+        // So is the interior, including the inner edge of the corner squares.
+        assert_eq!(alpha_at(&buf, w, 8, 8), 255);
+        assert_eq!(alpha_at(&buf, w, 20, 15), 255);
+        // And the curve is anti-aliased: somewhere along it a partial alpha.
+        let partial = (0..8)
+            .flat_map(|y| (0..8).map(move |x| (x, y)))
+            .any(|(x, y)| {
+                let a = alpha_at(&buf, w, x, y);
+                a > 0 && a < 255
+            });
+        assert!(partial, "expected an anti-aliased fringe on the arc");
+    }
+
+    #[test]
+    fn rounded_corners_respect_the_per_corner_mask() {
+        let (w, h) = (40u32, 30u32);
+        let mut buf = opaque(w, h);
+        apply_rounded_corners(&mut buf, w, h, 8.0, [true, false, false, false]);
+        assert_eq!(alpha_at(&buf, w, 0, 0), 0);
+        assert_eq!(alpha_at(&buf, w, w - 1, 0), 255);
+        assert_eq!(alpha_at(&buf, w, 0, h - 1), 255);
+        assert_eq!(alpha_at(&buf, w, w - 1, h - 1), 255);
+    }
+
+    #[test]
+    fn rounded_corners_zero_radius_is_a_no_op() {
+        let (w, h) = (12u32, 9u32);
+        let before = opaque(w, h);
+        let mut buf = before.clone();
+        apply_rounded_corners(&mut buf, w, h, 0.0, [true; 4]);
+        assert_eq!(buf, before);
+        apply_rounded_corners(&mut buf, w, h, 5.0, [false; 4]);
+        assert_eq!(buf, before);
+    }
+
+    #[test]
+    fn rounded_corners_survive_a_radius_larger_than_the_image() {
+        // A small window with a huge radius must not panic or invert: the
+        // radius clamps to half the shorter side (8 here), a stadium.
+        let (w, h) = (20u32, 16u32);
+        let mut buf = opaque(w, h);
+        apply_rounded_corners(&mut buf, w, h, 50.0, [true; 4]);
+        assert_eq!(alpha_at(&buf, w, 0, 0), 0);
+        assert_eq!(alpha_at(&buf, w, w - 1, h - 1), 0);
+        // The centre stays opaque, as does the middle of the long edge.
+        assert_eq!(alpha_at(&buf, w, 10, 8), 255);
+        assert_eq!(alpha_at(&buf, w, 10, 0), 255);
     }
 }

--- a/clowd_capture/src/interaction.rs
+++ b/clowd_capture/src/interaction.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant};
 use crate::ocr::OcrOutcome;
 use crate::selection::{dpi_at_point, hit_test, DragMode, Hittest};
 use crate::settings::TipsMode;
-use crate::system::MonitorInfo;
+use crate::system::{MonitorInfo, WindowTarget};
 use clowd_rust_core::geometry::{ScreenPoint, ScreenPointF, ScreenRect};
 use winit::window::CursorIcon;
 
@@ -273,6 +273,15 @@ pub(crate) struct InteractionState {
     pub mouse_down_dpi: f32,
     pub dragging: bool,
     pub selection: Option<ScreenRect>,
+    /// Corner radius of `selection` in physical px; 0 = square. Non-zero
+    /// only while the selection IS a window the user picked (hover, click
+    /// without drag, `W`, `--capture-mode window`) — it is the radius the
+    /// OS composites that window with. Every other way a rect comes to be
+    /// (drag-select, F / A, moving or resizing a captured window selection)
+    /// sets it back to 0: the rect no longer describes a window's shape.
+    /// Rides along to the render workers with the selection and into the
+    /// copy / save / preview crop.
+    pub selection_radius: f32,
     pub captured: bool,
     pub hittest: Hittest,
     pub drag_mode: Option<DragMode>,
@@ -314,6 +323,16 @@ pub(crate) struct InteractionEffects {
     pub update_cursor_visibility: bool,
     pub restore_mouse: Option<ScreenPoint>,
     pub set_cursor: Option<CursorIcon>,
+}
+
+impl InteractionState {
+    /// Point the un-captured selection at whatever the walker found under
+    /// the cursor — rect and corner radius together, or neither. The only
+    /// path by which `selection_radius` becomes non-zero.
+    pub fn set_hover_target(&mut self, target: Option<WindowTarget>) {
+        self.selection = target.map(|t| t.rect);
+        self.selection_radius = target.map_or(0.0, |t| t.corner_radius);
+    }
 }
 
 pub(crate) struct InteractionController;
@@ -359,8 +378,14 @@ impl InteractionController {
         }
     }
 
-    pub fn finalize_selection(input: &mut InteractionState, rect: ScreenRect, monitors: &[MonitorInfo]) -> InteractionEffects {
+    pub fn finalize_selection(
+        input: &mut InteractionState,
+        rect: ScreenRect,
+        corner_radius: f32,
+        monitors: &[MonitorInfo],
+    ) -> InteractionEffects {
         input.selection = Some(rect);
+        input.selection_radius = corner_radius;
         input.mouse_down = false;
         input.mouse_down_pt = None;
         input.dragging = false;
@@ -396,6 +421,7 @@ impl InteractionController {
 
     pub fn reset(input: &mut InteractionState) -> InteractionEffects {
         input.selection = None;
+        input.selection_radius = 0.0;
         input.captured = false;
         // Pick mode only means anything while a captured selection exists
         // to click inside; dropping the selection must drop the mode too,
@@ -451,6 +477,7 @@ mod tests {
             mouse_down_dpi: 1.0,
             dragging: true,
             selection: None,
+            selection_radius: 0.0,
             captured: false,
             hittest: Hittest::Outside,
             drag_mode: None,
@@ -488,9 +515,10 @@ mod tests {
         let mut input = state();
         let rect = ScreenRect::from_xy_size(20, 20, 40, 30);
 
-        let effects = InteractionController::finalize_selection(&mut input, rect, &[monitor()]);
+        let effects = InteractionController::finalize_selection(&mut input, rect, 12.0, &[monitor()]);
 
         assert_eq!(input.selection, Some(rect));
+        assert_eq!(input.selection_radius, 12.0);
         assert!(input.captured);
         assert!(!input.mouse_down);
         assert_eq!(input.zoom, 1.0);
@@ -519,6 +547,7 @@ mod tests {
         let mut input = state();
         input.captured = true;
         input.selection = Some(ScreenRect::from_xy_size(1, 1, 10, 10));
+        input.selection_radius = 16.0;
         input.scroll_pick_mode = true;
         input.ocr = OcrState::Lifted {
             anchor: Instant::now(),
@@ -536,6 +565,7 @@ mod tests {
 
         assert!(!input.captured);
         assert_eq!(input.selection, None);
+        assert_eq!(input.selection_radius, 0.0);
         assert!(!input.scroll_pick_mode);
         // The lifted lines were positioned against the selection that just
         // disappeared; leaving the mode up would draw them over nothing.

--- a/clowd_capture/src/render.rs
+++ b/clowd_capture/src/render.rs
@@ -449,6 +449,7 @@ fn render_worker_main(params: RenderWorkerParams, input_rx: mpsc::Receiver<Worke
             cursor_params: [0.0, 0.0, 0.0, 0.0],
             ocr_rect: [0.0, 0.0, -1.0, -1.0],
             ocr_params: [0.0, 0.0, 0.0, 0.0],
+            selection_shape: [0.0, 0.0, 0.0, 0.0],
         };
 
         let ubo = bundle
@@ -586,6 +587,8 @@ fn render_worker_main(params: RenderWorkerParams, input_rx: mpsc::Receiver<Worke
     let mut mouse_pos: ScreenPointF = cycle.initial_mouse;
     let mut zoom: f32 = 1.0;
     let mut selection: Option<ScreenRect> = None;
+    let mut selection_radius: f32 = 0.0;
+    let mut selection_dragging: bool = false;
     let mut captured: bool = false;
     let mut overlays_visible: bool = true;
     let mut cursor_overlay_visible: bool = true;
@@ -637,11 +640,15 @@ fn render_worker_main(params: RenderWorkerParams, input_rx: mpsc::Receiver<Worke
                     pos,
                     zoom: z,
                     selection: sel,
+                    selection_radius: radius,
+                    selection_dragging: dragging,
                     captured: cap,
                 }) => {
                     mouse_pos = pos;
                     zoom = z;
                     selection = sel;
+                    selection_radius = radius;
+                    selection_dragging = dragging;
                     captured = cap;
                 }
                 Ok(RenderMsg::UiState(state)) => {
@@ -778,6 +785,8 @@ fn render_worker_main(params: RenderWorkerParams, input_rx: mpsc::Receiver<Worke
                     mouse_pos,
                     zoom,
                     selection,
+                    selection_radius,
+                    selection_dragging,
                     captured,
                     overlays_visible,
                     cursor_overlay_visible,
@@ -843,6 +852,10 @@ fn render_worker_main(params: RenderWorkerParams, input_rx: mpsc::Receiver<Worke
 
             let mut peek_uniforms = PeekUniforms::zeroed();
             peek_uniforms.selection_rect = [sl, st, sr, sb];
+            // Same window-local scaling as the desktop pass's
+            // selection_shape: the radius rides the magnifier zoom with
+            // the rect it belongs to.
+            peek_uniforms.selection_shape = [selection_radius * zoom.max(1.0), 0.0, 0.0, 0.0];
             peek_uniforms.window_uv = window_uv;
             peek_uniforms.desktop_uv = desktop_uv;
 

--- a/clowd_capture/src/render/desktop.rs
+++ b/clowd_capture/src/render/desktop.rs
@@ -31,6 +31,11 @@ pub(crate) struct FrameState {
     pub mouse_pos: ScreenPointF,
     pub zoom: f32,
     pub selection: Option<ScreenRect>,
+    /// Corner radius of `selection` in virtual-desktop px (0 = square).
+    pub selection_radius: f32,
+    /// The selection is mid-drag (button down): its rect changes every
+    /// frame, so the dash period must not re-snap to it.
+    pub selection_dragging: bool,
     pub captured: bool,
     pub overlays_visible: bool,
     pub cursor_overlay_visible: bool,
@@ -64,6 +69,8 @@ impl SnapshotState {
             mouse_pos,
             zoom,
             selection,
+            selection_radius,
+            selection_dragging,
             captured,
             overlays_visible,
             cursor_overlay_visible,
@@ -138,6 +145,7 @@ impl SnapshotState {
                 ];
             }
             self.uniforms.selection_rect = [0.0, 0.0, -1.0, -1.0];
+            self.uniforms.selection_shape = [0.0; 4];
             self.uniforms.selection_params[0] = elapsed;
             self.uniforms.selection_params[1] = 0.0;
             self.uniforms.selection_params[2] = zoom;
@@ -179,8 +187,27 @@ impl SnapshotState {
             let (l, t) = to_local(sel_f.left(), sel_f.top());
             let (r, b) = to_local(sel_f.right(), sel_f.bottom());
             self.uniforms.selection_rect = [l, t, r, b];
+            // The radius is a length in the same space as the rect, so it
+            // scales with the magnifier like the rect's edges do.
+            let radius_local = selection_radius.max(0.0) * zoom.max(1.0);
+            // Dash period: snapped to the border's perimeter (same DPI
+            // step rule the shader uses for the stroke) so the pattern
+            // wraps without a cut dash — square or rounded — except
+            // while a drag is in progress: the rect changes every frame
+            // then, and a period that tracked it would re-phase every
+            // dash along the walk under the cursor. Nominal mid-drag;
+            // re-snapped once on release.
+            let dpi_step = self.uniforms.params[3].max(1.0).floor();
+            let nominal = NOMINAL_DASH_PERIOD * dpi_step;
+            let period = if selection_dragging {
+                nominal
+            } else {
+                dash_period(nominal, border_perimeter(r - l, b - t, radius_local))
+            };
+            self.uniforms.selection_shape = [radius_local, period, 0.0, 0.0];
         } else {
             self.uniforms.selection_rect = [0.0, 0.0, -1.0, -1.0];
+            self.uniforms.selection_shape = [0.0; 4];
         }
 
         self.uniforms.selection_params[0] = elapsed;
@@ -224,6 +251,45 @@ impl SnapshotState {
         self.uniforms.cursor_rect = [l, t, r, b];
         self.uniforms.cursor_params = [ct.cursor_type as f32, 0.0, 0.0, 0.0];
     }
+}
+
+// ── Selection border dashes ─────────────────────────────────────────
+
+/// Marching-ants dash period at 100 % DPI, physical px: 16 on + 16 off.
+/// Matches the C++ D2D stroke style of {8, 8} × 2 DIPs
+/// (DxScreenCapture.cpp:638-645) and the shader's own constant.
+pub(crate) const NOMINAL_DASH_PERIOD: f32 = 32.0;
+
+/// Length of the path the dashes walk: the selection border's perimeter
+/// in px for a `w`×`h` rect with corner radius `r` (0 = square). For the
+/// square border this is the integer path's `2 * top_len + 2 * side_len`
+/// (the stroke's extra `half` on the top/bottom runs cancels the `half`
+/// the sides give up); the rounded path swaps four corners for one
+/// circle's worth of arc. `r` is clamped like the shader clamps it.
+pub(crate) fn border_perimeter(w: f32, h: f32, r: f32) -> f32 {
+    let w = w.max(0.0);
+    let h = h.max(0.0);
+    let r = r.clamp(0.0, w.min(h) * 0.5);
+    2.0 * (w + h) - 8.0 * r + 2.0 * std::f32::consts::PI * r
+}
+
+/// The dash period that divides `perimeter` a whole number of times,
+/// nearest to `nominal`. Without it the pattern wraps at a fractional
+/// period and the walk's start shows a seam where one dash is cut short;
+/// with it the ants march as one continuous loop, at the cost of dashes
+/// up to half a period longer or shorter than nominal — a few percent on
+/// anything bigger than a button. NOT applied while the selection is
+/// being dragged: the perimeter then changes every frame and the snapped
+/// period with it, which re-phases every dash along the walk and reads
+/// as the far end jittering.
+pub(crate) fn dash_period(nominal: f32, perimeter: f32) -> f32 {
+    // Degenerate or NaN inputs: hand back the nominal period untouched
+    // rather than a 0 / inf / NaN the shader would have to guard against.
+    if nominal <= 0.0 || perimeter <= 0.0 || nominal.is_nan() || perimeter.is_nan() {
+        return nominal;
+    }
+    let n = (perimeter / nominal).round().max(1.0);
+    perimeter / n
 }
 
 // ── OCR dim + desaturation ──────────────────────────────────────────
@@ -366,6 +432,37 @@ mod tests {
         let mid_g = retracting_gray(anim::RETRACT_DURATION_SECS * 0.5);
         assert!((0.0..=anim::DIM_MAX).contains(&mid_d));
         assert!((0.0..=1.0).contains(&mid_g));
+    }
+
+    /// A snapped period divides the perimeter exactly and never strays more
+    /// than half a nominal period from nominal.
+    #[test]
+    fn dash_period_divides_perimeter_and_stays_near_nominal() {
+        for perimeter in [100.0f32, 333.0, 1000.0, 4097.5, 20_000.0] {
+            let p = dash_period(32.0, perimeter);
+            let n = perimeter / p;
+            assert!((n - n.round()).abs() < 1e-3, "perimeter {perimeter}: {n} periods");
+            assert!((p - 32.0).abs() <= 16.0 + 1e-3, "perimeter {perimeter}: period {p}");
+        }
+        // Exactly divisible: untouched.
+        assert_eq!(dash_period(32.0, 320.0), 32.0);
+        // Tiny selection: one dash round the whole thing, never zero.
+        assert_eq!(dash_period(32.0, 10.0), 10.0);
+        // Degenerate inputs fall back to nominal rather than NaN/inf.
+        assert_eq!(dash_period(32.0, 0.0), 32.0);
+        assert_eq!(dash_period(32.0, -5.0), 32.0);
+        assert_eq!(dash_period(0.0, 100.0), 0.0);
+    }
+
+    /// The square perimeter is 2(w+h); rounding trades 8r of corners for a
+    /// full circle of arc, and a radius past half the short side clamps.
+    #[test]
+    fn border_perimeter_square_and_rounded() {
+        assert_eq!(border_perimeter(100.0, 50.0, 0.0), 300.0);
+        let rounded = border_perimeter(100.0, 50.0, 10.0);
+        assert!((rounded - (300.0 - 80.0 + 2.0 * std::f32::consts::PI * 10.0)).abs() < 1e-3);
+        // Radius clamps to 25 (half of 50): a stadium.
+        assert_eq!(border_perimeter(100.0, 50.0, 1000.0), border_perimeter(100.0, 50.0, 25.0));
     }
 
     /// The shared curve's endpoints: byte-exact passthrough at t=0 (the

--- a/clowd_capture/src/render/protocol.rs
+++ b/clowd_capture/src/render/protocol.rs
@@ -14,6 +14,12 @@ pub enum RenderMsg {
         pos: ScreenPointF,
         zoom: f32,
         selection: Option<ScreenRect>,
+        /// Corner radius of `selection` in physical (virtual-desktop) px,
+        /// 0 = square — see `InteractionState::selection_radius`.
+        selection_radius: f32,
+        /// A mouse button is down — the selection is being dragged out,
+        /// moved or resized and its geometry changes every frame.
+        selection_dragging: bool,
         captured: bool,
     },
     UiState(Arc<UiSharedState>),

--- a/clowd_capture/src/render/window.rs
+++ b/clowd_capture/src/render/window.rs
@@ -206,19 +206,30 @@ impl WindowHandle {
     pub fn save_to_file_with_peek(
         &self,
         selection: ScreenRect,
+        corner_radius: f32,
         buffer: &CapturedDesktop,
         peek: Option<&WindowPeekImage>,
         cursor: Option<&CapturedCursor>,
         cursor_visible: bool,
     ) -> ActionResult {
-        save_to_file_with_peek(selection, buffer, peek, cursor, cursor_visible, &self.window)
+        save_to_file_with_peek(selection, corner_radius, buffer, peek, cursor, cursor_visible, &self.window)
     }
 
-    pub fn update_mouse_state(&self, pos: ScreenPointF, zoom: f32, selection: Option<ScreenRect>, captured: bool) {
+    pub fn update_mouse_state(
+        &self,
+        pos: ScreenPointF,
+        zoom: f32,
+        selection: Option<ScreenRect>,
+        selection_radius: f32,
+        selection_dragging: bool,
+        captured: bool,
+    ) {
         let _ = self.tx.send(RenderMsg::MouseState {
             pos,
             zoom,
             selection,
+            selection_radius,
+            selection_dragging,
             captured,
         });
     }

--- a/clowd_capture/src/session_output.rs
+++ b/clowd_capture/src/session_output.rs
@@ -20,7 +20,9 @@ use clowd_rust_core::geometry::{RectExt, ScreenPoint, ScreenRect};
 use clowd_rust_core::session::{absolute_path, created_utc_now, save_png, SessionJson};
 
 use crate::capture_output::ActionResult;
-use crate::image_extract::{composite_cursor_rgba, extract_selection_rgba, extract_selection_rgba_with_peek};
+use crate::image_extract::{
+    apply_rounded_corners, composite_cursor_rgba, corners_to_round, extract_selection_rgba, extract_selection_rgba_with_peek,
+};
 use crate::system::{virtual_desktop_bounds, CapturedDesktop, CursorImage, MonitorInfo, WindowPeekImage};
 
 /// Name of the sidecar file the shell reads to route the finished
@@ -47,12 +49,13 @@ pub enum SessionAction {
 pub fn write_session(
     session_dir: &Path,
     selection: ScreenRect,
+    corner_radius: f32,
     buffer: &CapturedDesktop,
     peek: Option<&WindowPeekImage>,
     cursor_visible: bool,
     action: SessionAction,
 ) -> ActionResult {
-    match write_session_inner(session_dir, selection, buffer, peek, cursor_visible, action) {
+    match write_session_inner(session_dir, selection, corner_radius, buffer, peek, cursor_visible, action) {
         Ok(json_path) => {
             log::info!("session written to {:?}", json_path);
             ActionResult::Success
@@ -390,6 +393,7 @@ fn write_ocr_upload_action_inner(session_dir: &Path, text: &str) -> anyhow::Resu
 fn write_session_inner(
     session_dir: &Path,
     selection: ScreenRect,
+    corner_radius: f32,
     buffer: &CapturedDesktop,
     peek: Option<&WindowPeekImage>,
     cursor_visible: bool,
@@ -400,9 +404,19 @@ fn write_session_inner(
 
     // Selection clamped to the desktop bitmap; this is the region the
     // preview contains and what CroppedRect must describe.
+    let requested = selection;
     let selection = selection
         .intersection(&buffer.bounds)
         .ok_or_else(|| anyhow!("selection {:?} does not intersect desktop bounds {:?}", selection, buffer.bounds))?;
+    // A picked window's corners go transparent in the PREVIEW only (the
+    // image UPLOAD ships and the editor shows first). desktop.png stays a
+    // plain bitmap — the editor crops it by CroppedRect itself — and a
+    // corner the clamp cut off is not a corner.
+    let preview_corners = if corner_radius > 0.0 {
+        corners_to_round(requested, selection)
+    } else {
+        [false; 4]
+    };
 
     // The three image extract+encode jobs are independent; run them on
     // scoped threads so the wall time is the largest single encode
@@ -462,6 +476,7 @@ fn write_session_inner(
                     composite_cursor_rgba(&mut rgba, w, h, selection, cur);
                 }
             }
+            apply_rounded_corners(&mut rgba, w, h, corner_radius, preview_corners);
             save_png(&preview_path, rgba, w, h)
         });
 
@@ -512,6 +527,7 @@ fn write_session_inner(
         }),
         cropped_rect: cropped_rect.into(),
         original_bounds: selection.into(),
+        corner_radius,
     };
 
     let json_path = session_dir.join("session.json");

--- a/clowd_capture/src/settings.rs
+++ b/clowd_capture/src/settings.rs
@@ -93,6 +93,16 @@ pub struct CapturerSettings {
     /// regardless; this only controls visibility. Toggled at runtime
     /// with the `M` key.
     pub cursor_visible_at_startup: bool,
+    /// When enabled, a selection made by picking a window (hover + click,
+    /// `W`, `--capture-mode window`) takes on that window's OS corner
+    /// radius: the dashed border is drawn rounded and the copied / saved /
+    /// previewed image has transparent corners instead of a few pixels of
+    /// whatever sat behind the window. Dragged selections — and a window
+    /// selection once it has been moved or resized — stay square. The
+    /// radius comes from the OS where it can be asked (DWM on Windows 11,
+    /// the window server's own corner mask on macOS) and from a per-version
+    /// table otherwise; see `system::corners`.
+    pub rounded_window_corners: bool,
     /// Directory to write the session payload into, supplied by the
     /// shell via `--session-dir <path>`. When set, the EDIT/UPLOAD
     /// actions write desktop/cursor/preview PNGs plus `session.json`
@@ -135,6 +145,7 @@ impl Default for CapturerSettings {
             obscured_window_peek_enabled: true,
             obscured_window_detection_threshold: 0.80,
             cursor_visible_at_startup: true,
+            rounded_window_corners: true,
             session_dir: None,
             capture_mode: CaptureMode::default(),
             video_mode: false,
@@ -181,6 +192,12 @@ pub struct CliArgs {
     /// Start with the captured cursor hidden (toggled at runtime with M).
     #[arg(long)]
     pub no_cursor: bool,
+
+    /// Keep window selections square: do not round the selection border to
+    /// the window's OS corner radius, and do not leave those corner pixels
+    /// transparent in the copied / saved image.
+    #[arg(long)]
+    pub no_rounded_corners: bool,
 
     /// What to have selected when the capturer opens. `region` (default)
     /// starts the free-selection crosshair; `screen` pre-selects the
@@ -249,6 +266,7 @@ impl CliArgs {
             obscured_window_peek_enabled: !self.no_peek,
             obscured_window_detection_threshold: self.peek_threshold,
             cursor_visible_at_startup: !self.no_cursor,
+            rounded_window_corners: !self.no_rounded_corners,
             session_dir: self.session_dir,
             capture_mode: self.capture_mode,
             video_mode: self.video,
@@ -300,6 +318,7 @@ mod tests {
             default.obscured_window_detection_threshold
         );
         assert_eq!(from_cli.cursor_visible_at_startup, default.cursor_visible_at_startup);
+        assert_eq!(from_cli.rounded_window_corners, default.rounded_window_corners);
         assert_eq!(from_cli.session_dir, default.session_dir);
         assert_eq!(from_cli.capture_mode, default.capture_mode);
         assert_eq!(from_cli.video_mode, default.video_mode);
@@ -327,6 +346,22 @@ mod tests {
         let no_ocr = CliArgs::parse_from(["clowd_capture_wgpu", "--no-ocr"]).into_settings();
         assert!(!no_ocr.panel_features.ocr);
         assert!(no_ocr.panel_features.upload && no_ocr.panel_features.scroll_capture);
+    }
+
+    /// Rounded corners are on by a bare command line and `--no-rounded-corners`
+    /// is the only way off — opt-out like the rest of the behaviour flags.
+    #[test]
+    fn rounded_corners_flag_is_opt_out() {
+        assert!(
+            CliArgs::parse_from(["clowd_capture_wgpu"])
+                .into_settings()
+                .rounded_window_corners
+        );
+        assert!(
+            !CliArgs::parse_from(["clowd_capture_wgpu", "--no-rounded-corners"])
+                .into_settings()
+                .rounded_window_corners
+        );
     }
 
     #[test]

--- a/clowd_capture/src/system/corners.rs
+++ b/clowd_capture/src/system/corners.rs
@@ -1,0 +1,335 @@
+//! Window corner radius — the platform-neutral half.
+//!
+//! Every OS since Windows 11 / macOS 11 composites top-level windows with
+//! rounded corners, and the radius differs per OS, per OS version, and (on
+//! macOS Tahoe) per window style. The capturer wants that radius for two
+//! things: drawing the selection border as the same rounded shape the user
+//! sees, and leaving the corner pixels transparent in the copied/saved
+//! image instead of shipping a few pixels of whatever sat behind the
+//! window.
+//!
+//! This module holds the decisions that need no OS call so they can be
+//! unit-tested on any host: the Windows 11 rounding policy
+//! ([`windows_corner_radius_logical`]), the macOS lookup table used until
+//! (or if) the window server can be asked ([`macos_fallback_radius_points`]),
+//! and the estimator that turns a captured corner's alpha channel into a
+//! radius ([`estimate_radius_from_alpha`]). The Win32 / CoreGraphics glue
+//! lives next to each walker.
+
+// The Windows policy half is only called from the Win32 walker; it is
+// compiled (and its tests run) everywhere so a mac-hosted build still checks it.
+#![cfg_attr(not(windows), allow(dead_code))]
+
+/// First Windows 11 build. Windows 10 never rounds.
+pub const WINDOWS_11_FIRST_BUILD: u32 = 22000;
+
+/// DWM's `DWMWCP_ROUND` radius at 96 DPI (Windows 11 Geometry: top-level
+/// windows round at 8 px, auxiliary UI at 4 px).
+pub const WIN11_ROUND_LOGICAL: f32 = 8.0;
+/// DWM's `DWMWCP_ROUNDSMALL` radius at 96 DPI.
+pub const WIN11_ROUND_SMALL_LOGICAL: f32 = 4.0;
+
+/// Below this (physical px) a measured radius is noise — an AA fringe on a
+/// square window, not a curve.
+pub const MIN_MEASURED_RADIUS_PX: f32 = 2.0;
+
+/// `DWMWA_WINDOW_CORNER_PREFERENCE`, as read back from DWM.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CornerPreference {
+    /// `DWMWCP_DEFAULT` — the system decides.
+    Default,
+    /// `DWMWCP_DONOTROUND`.
+    DoNotRound,
+    /// `DWMWCP_ROUND`.
+    Round,
+    /// `DWMWCP_ROUNDSMALL`.
+    RoundSmall,
+}
+
+/// The inputs to the Windows 11 rounding policy for one top-level window.
+#[derive(Debug, Clone, Copy)]
+pub struct WindowsCornerInputs {
+    /// `RtlGetVersion().dwBuildNumber`.
+    pub build: u32,
+    /// `GetSystemMetrics(SM_REMOTESESSION) != 0` — DWM does not round in
+    /// remote / VM sessions.
+    pub remote_session: bool,
+    /// `IsZoomed(hwnd)` — maximized windows are never rounded.
+    pub maximized: bool,
+    /// `IsWindowArranged(hwnd)` — snapped windows are never rounded.
+    pub arranged: bool,
+    /// What `DwmGetWindowAttribute(DWMWA_WINDOW_CORNER_PREFERENCE)` said,
+    /// or `None` when the attribute could not be read.
+    pub preference: Option<CornerPreference>,
+    /// `GetWindowRgn` returned a real region — windows shaped with
+    /// `SetWindowRgn` are never rounded.
+    pub has_region: bool,
+    /// The window has a frame DWM can round: full `WS_CAPTION` or
+    /// `WS_THICKFRAME`.
+    pub has_frame: bool,
+}
+
+/// Corner radius in *logical* (96-DPI) pixels for a Windows top-level
+/// window. 0 = square. Mirrors the policy documented in "Apply rounded
+/// corners in desktop apps": never on Windows 10, never when maximized /
+/// snapped / remote, an explicit DWM preference wins, otherwise only
+/// framed, un-regioned windows round at the default 8 px.
+pub fn windows_corner_radius_logical(i: WindowsCornerInputs) -> f32 {
+    if i.build < WINDOWS_11_FIRST_BUILD || i.remote_session || i.maximized || i.arranged {
+        return 0.0;
+    }
+    match i.preference {
+        Some(CornerPreference::DoNotRound) => 0.0,
+        Some(CornerPreference::Round) => WIN11_ROUND_LOGICAL,
+        Some(CornerPreference::RoundSmall) => WIN11_ROUND_SMALL_LOGICAL,
+        Some(CornerPreference::Default) | None => {
+            if i.has_region || !i.has_frame {
+                0.0
+            } else {
+                WIN11_ROUND_LOGICAL
+            }
+        }
+    }
+}
+
+/// macOS window corner radius in points for an OS major version, used when
+/// the window server cannot be asked (the probe in `mac_corners` is the
+/// primary source — Tahoe alone has at least three radii depending on the
+/// window's chrome). Big Sur through Sequoia: 10 pt. Tahoe: 16 pt is the
+/// titlebar-only default (toolbar windows are 26 pt, which the probe picks
+/// up). Anything older or newer than the table: 0, i.e. square.
+pub fn macos_fallback_radius_points(major: i64) -> f32 {
+    match major {
+        11..=15 => 10.0,
+        26 => 16.0,
+        _ => 0.0,
+    }
+}
+
+/// Which corner of the window a probe image covers; the estimator flips
+/// the buffer so the curve is always analysed as if it were top-left.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Corner {
+    TopLeft,
+    TopRight,
+    BottomLeft,
+    BottomRight,
+}
+
+/// Estimate a circular corner radius (in the buffer's pixel units) from
+/// the alpha channel of a `w`×`h` image whose `corner` coincides with the
+/// window's corner. `alpha(x, y)` returns 0..=255.
+///
+/// Method: the transparent area of a quarter circle cut from a square is
+/// `(1 - π/4)·r²`, so `r = sqrt(A / (1 - π/4))`. Two corrections make that
+/// robust against the window server's anti-aliasing: the straight edges
+/// adjoining the corner also carry a fractional-alpha fringe, estimated
+/// from the 8 rows / columns farthest from the corner (straight edge there
+/// as long as the probe is larger than the radius) and subtracted; and
+/// radii under [`MIN_MEASURED_RADIUS_PX`] collapse to 0, since a square
+/// window still measures a fraction of a pixel from its edge fringe.
+pub fn estimate_radius_from_alpha(w: usize, h: usize, corner: Corner, alpha: impl Fn(usize, usize) -> u8) -> f32 {
+    if w < 4 || h < 4 {
+        return 0.0;
+    }
+    // Re-index so the corner of interest is at (0, 0).
+    let at = |x: usize, y: usize| -> f32 {
+        let (sx, sy) = match corner {
+            Corner::TopLeft => (x, y),
+            Corner::TopRight => (w - 1 - x, y),
+            Corner::BottomLeft => (x, h - 1 - y),
+            Corner::BottomRight => (w - 1 - x, h - 1 - y),
+        };
+        1.0 - alpha(sx, sy) as f32 / 255.0
+    };
+
+    let mut total = 0.0f32;
+    for y in 0..h {
+        for x in 0..w {
+            total += at(x, y);
+        }
+    }
+
+    // Straight-edge fringe: mean transparency per row along the left edge
+    // (taken far from the corner) and per column along the top edge.
+    let band = 8.min(h / 2).min(w / 2).max(1);
+    let mut left_edge = 0.0f32;
+    for y in (h - band)..h {
+        for x in 0..w {
+            left_edge += at(x, y);
+        }
+    }
+    left_edge /= band as f32;
+    let mut top_edge = 0.0f32;
+    for x in (w - band)..w {
+        for y in 0..h {
+            top_edge += at(x, y);
+        }
+    }
+    top_edge /= band as f32;
+
+    let corner_area = (total - left_edge * h as f32 - top_edge * w as f32).max(0.0);
+    let r = (corner_area / (1.0 - std::f32::consts::FRAC_PI_4)).sqrt();
+    if r < MIN_MEASURED_RADIUS_PX {
+        0.0
+    } else {
+        r
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn inputs() -> WindowsCornerInputs {
+        WindowsCornerInputs {
+            build: 22631,
+            remote_session: false,
+            maximized: false,
+            arranged: false,
+            preference: None,
+            has_region: false,
+            has_frame: true,
+        }
+    }
+
+    #[test]
+    fn windows_10_never_rounds() {
+        let i = WindowsCornerInputs {
+            build: 19045,
+            preference: Some(CornerPreference::Round),
+            ..inputs()
+        };
+        assert_eq!(windows_corner_radius_logical(i), 0.0);
+    }
+
+    #[test]
+    fn windows_11_framed_window_rounds_by_default() {
+        assert_eq!(windows_corner_radius_logical(inputs()), WIN11_ROUND_LOGICAL);
+        let default_pref = WindowsCornerInputs {
+            preference: Some(CornerPreference::Default),
+            ..inputs()
+        };
+        assert_eq!(windows_corner_radius_logical(default_pref), WIN11_ROUND_LOGICAL);
+    }
+
+    #[test]
+    fn maximized_snapped_remote_and_regioned_windows_are_square() {
+        for i in [
+            WindowsCornerInputs {
+                maximized: true,
+                ..inputs()
+            },
+            WindowsCornerInputs {
+                arranged: true,
+                ..inputs()
+            },
+            WindowsCornerInputs {
+                remote_session: true,
+                ..inputs()
+            },
+            WindowsCornerInputs {
+                has_region: true,
+                ..inputs()
+            },
+            WindowsCornerInputs {
+                has_frame: false,
+                ..inputs()
+            },
+        ] {
+            assert_eq!(windows_corner_radius_logical(i), 0.0, "{i:?}");
+        }
+    }
+
+    #[test]
+    fn explicit_dwm_preference_wins_over_the_heuristic() {
+        // An unframed popup that opted in (e.g. a custom menu) rounds.
+        let small = WindowsCornerInputs {
+            has_frame: false,
+            preference: Some(CornerPreference::RoundSmall),
+            ..inputs()
+        };
+        assert_eq!(windows_corner_radius_logical(small), WIN11_ROUND_SMALL_LOGICAL);
+        let round = WindowsCornerInputs {
+            has_frame: false,
+            preference: Some(CornerPreference::Round),
+            ..inputs()
+        };
+        assert_eq!(windows_corner_radius_logical(round), WIN11_ROUND_LOGICAL);
+        // And a framed window that opted out stays square.
+        let none = WindowsCornerInputs {
+            preference: Some(CornerPreference::DoNotRound),
+            ..inputs()
+        };
+        assert_eq!(windows_corner_radius_logical(none), 0.0);
+    }
+
+    #[test]
+    fn macos_table_covers_big_sur_through_tahoe_only() {
+        assert_eq!(macos_fallback_radius_points(10), 0.0);
+        assert_eq!(macos_fallback_radius_points(11), 10.0);
+        assert_eq!(macos_fallback_radius_points(15), 10.0);
+        assert_eq!(macos_fallback_radius_points(26), 16.0);
+        // Unknown future releases: square rather than a guess.
+        assert_eq!(macos_fallback_radius_points(27), 0.0);
+        assert_eq!(macos_fallback_radius_points(99), 0.0);
+    }
+
+    /// Synthetic window corner: a quarter circle of radius `r` at the
+    /// given corner with ~1 px linear anti-aliasing, plus a faint fringe
+    /// along both straight edges like the window server produces.
+    fn synthetic_alpha(w: usize, h: usize, r: f32, corner: Corner) -> Vec<u8> {
+        let mut buf = vec![255u8; w * h];
+        for y in 0..h {
+            for x in 0..w {
+                let (cx, cy) = match corner {
+                    Corner::TopLeft => (x, y),
+                    Corner::TopRight => (w - 1 - x, y),
+                    Corner::BottomLeft => (x, h - 1 - y),
+                    Corner::BottomRight => (w - 1 - x, h - 1 - y),
+                };
+                let px = cx as f32 + 0.5;
+                let py = cy as f32 + 0.5;
+                let mut cov = 1.0f32;
+                if px < r && py < r {
+                    let d = ((px - r).powi(2) + (py - r).powi(2)).sqrt() - r;
+                    cov = (0.5 - d).clamp(0.0, 1.0);
+                }
+                // Straight-edge fringe: the outermost row/column is 80 % opaque.
+                if cx == 0 || cy == 0 {
+                    cov *= 0.8;
+                }
+                buf[y * w + x] = (cov * 255.0).round() as u8;
+            }
+        }
+        buf
+    }
+
+    #[test]
+    fn estimator_recovers_synthetic_radii_at_every_corner() {
+        for corner in [Corner::TopLeft, Corner::TopRight, Corner::BottomLeft, Corner::BottomRight] {
+            for r in [16.0f32, 24.0, 32.0, 52.0] {
+                let (w, h) = (96, 96);
+                let buf = synthetic_alpha(w, h, r, corner);
+                let est = estimate_radius_from_alpha(w, h, corner, |x, y| buf[y * w + x]);
+                assert!((est - r).abs() < 1.5, "corner {corner:?} r={r}: estimated {est}");
+            }
+        }
+    }
+
+    #[test]
+    fn estimator_reports_square_for_a_square_window() {
+        let (w, h) = (96, 96);
+        let buf = synthetic_alpha(w, h, 0.0, Corner::TopLeft);
+        assert_eq!(estimate_radius_from_alpha(w, h, Corner::TopLeft, |x, y| buf[y * w + x]), 0.0);
+        // Fully opaque, no fringe at all.
+        assert_eq!(estimate_radius_from_alpha(w, h, Corner::TopLeft, |_, _| 255), 0.0);
+    }
+
+    #[test]
+    fn estimator_tolerates_a_probe_smaller_than_the_band() {
+        // Degenerate sizes must not panic or index out of range.
+        assert_eq!(estimate_radius_from_alpha(2, 2, Corner::TopLeft, |_, _| 0), 0.0);
+        let _ = estimate_radius_from_alpha(5, 9, Corner::BottomRight, |_, _| 0);
+    }
+}

--- a/clowd_capture/src/system/corners.rs
+++ b/clowd_capture/src/system/corners.rs
@@ -16,9 +16,11 @@
 //! radius ([`estimate_radius_from_alpha`]). The Win32 / CoreGraphics glue
 //! lives next to each walker.
 
-// The Windows policy half is only called from the Win32 walker; it is
-// compiled (and its tests run) everywhere so a mac-hosted build still checks it.
-#![cfg_attr(not(windows), allow(dead_code))]
+// Each half is only called from its own platform's walker glue — the
+// Windows policy from `win_corners`, the macOS table + alpha estimator from
+// `mac_corners` — but the whole module is compiled (and its tests run) on
+// every host so either build still checks the other platform's logic.
+#![allow(dead_code)]
 
 /// First Windows 11 build. Windows 10 never rounds.
 pub const WINDOWS_11_FIRST_BUILD: u32 = 22000;

--- a/clowd_capture/src/system/mac_corners.rs
+++ b/clowd_capture/src/system/mac_corners.rs
@@ -1,0 +1,108 @@
+//! macOS glue for [`super::corners`]: the OS-version lookup used until the
+//! window server has been asked, and the probe that asks it.
+//!
+//! There is no public API that reports an `NSWindow`'s corner radius from
+//! outside its process, and on macOS Tahoe there is no single answer anyway
+//! (toolbar windows, titlebar-only windows and Catalyst/custom windows all
+//! differ). What IS available is the window server's own composite: a
+//! single-window `CGWindowListCreateImage` carries the corner mask in its
+//! alpha channel, so capturing a few dozen points at one corner of the
+//! window and measuring the transparent area gives the exact radius the
+//! user sees — for any app, on any version. It costs a window-server
+//! round-trip (~10 ms) per window, which is why the walker runs it after
+//! publishing the snapshot rather than before.
+
+use core_graphics::geometry::{CGPoint, CGRect, CGSize};
+use core_graphics::window::{self, kCGWindowImageBestResolution, kCGWindowImageBoundsIgnoreFraming, kCGWindowListOptionIncludingWindow};
+use objc2_foundation::NSProcessInfo;
+
+use super::corners::{estimate_radius_from_alpha, macos_fallback_radius_points, Corner};
+use super::MonitorInfo;
+
+/// Side of the square captured at a window corner, in CG points. Has to
+/// exceed the largest radius in use (26 pt on Tahoe) with room for the
+/// straight-edge band the estimator calibrates against.
+const PROBE_POINTS: f64 = 48.0;
+
+/// Major OS version from `NSProcessInfo`, read once.
+fn os_major_version() -> i64 {
+    use std::sync::OnceLock;
+    static MAJOR: OnceLock<i64> = OnceLock::new();
+    *MAJOR.get_or_init(|| {
+        NSProcessInfo::processInfo()
+            .operatingSystemVersion()
+            .majorVersion as i64
+    })
+}
+
+/// The lookup-table radius for this OS, in points. Used for every window
+/// until its probe lands, and for any window the probe cannot measure.
+pub fn fallback_radius_points() -> f32 {
+    macos_fallback_radius_points(os_major_version())
+}
+
+/// A window's CG-space bounds (points, top-left origin, as
+/// `kCGWindowBounds` reports them).
+#[derive(Debug, Clone, Copy)]
+pub struct CgBounds {
+    pub x: f64,
+    pub y: f64,
+    pub w: f64,
+    pub h: f64,
+}
+
+/// Measure the corner radius the window server composites `window_id`
+/// with, in physical pixels. `None` when no corner of the window sits
+/// fully on a display (nothing to photograph) or the capture failed — the
+/// caller keeps the lookup-table value then.
+pub fn probe_corner_radius(window_id: u32, bounds: CgBounds, monitors: &[MonitorInfo]) -> Option<f32> {
+    let side = PROBE_POINTS.min(bounds.w).min(bounds.h);
+    if side < 4.0 {
+        return None;
+    }
+    // Try the four corners in turn; a window half off the left of the
+    // display still has a right-hand corner to measure.
+    let candidates = [
+        (Corner::TopLeft, bounds.x, bounds.y),
+        (Corner::TopRight, bounds.x + bounds.w - side, bounds.y),
+        (Corner::BottomLeft, bounds.x, bounds.y + bounds.h - side),
+        (Corner::BottomRight, bounds.x + bounds.w - side, bounds.y + bounds.h - side),
+    ];
+    let (corner, x, y) = candidates.into_iter().find(|&(_, x, y)| {
+        monitors
+            .iter()
+            .any(|m| contains_square(m, x, y, side))
+    })?;
+
+    let rect = CGRect::new(&CGPoint::new(x, y), &CGSize::new(side, side));
+    let image = window::create_image(
+        rect,
+        kCGWindowListOptionIncludingWindow,
+        window_id,
+        kCGWindowImageBestResolution | kCGWindowImageBoundsIgnoreFraming,
+    )?;
+    let w = image.width();
+    let h = image.height();
+    let bpr = image.bytes_per_row();
+    if image.bits_per_pixel() != 32 || w == 0 || h == 0 {
+        return None;
+    }
+    let data = image.data();
+    let bytes = data.bytes();
+    if bytes.len() < (h - 1) * bpr + w * 4 {
+        return None;
+    }
+    // Same pixel layout `capture_window_image` relies on: BGRA, alpha last.
+    let alpha = |px: usize, py: usize| -> u8 { bytes[py * bpr + px * 4 + 3] };
+    Some(estimate_radius_from_alpha(w, h, corner, alpha))
+}
+
+/// Whether the `side`-pt square at CG point (`x`, `y`) lies entirely on
+/// monitor `m`.
+fn contains_square(m: &MonitorInfo, x: f64, y: f64, side: f64) -> bool {
+    let ox = m.logical_origin.x;
+    let oy = m.logical_origin.y;
+    let lw = m.bounds.width() as f64 / m.scale_factor as f64;
+    let lh = m.bounds.height() as f64 / m.scale_factor as f64;
+    x >= ox && y >= oy && x + side <= ox + lw && y + side <= oy + lh
+}

--- a/clowd_capture/src/system/mac_walker.rs
+++ b/clowd_capture/src/system/mac_walker.rs
@@ -5,6 +5,7 @@
 //! no child-window walking.
 
 use std::ffi::c_void;
+use std::sync::Mutex;
 
 use core_foundation::base::TCFType;
 use core_foundation::dictionary::{CFDictionary, CFDictionaryRef};
@@ -14,7 +15,8 @@ use core_graphics::display::CGDisplay;
 use core_graphics::geometry::CGRect;
 use core_graphics::window::{self, kCGNullWindowID, kCGWindowListExcludeDesktopElements, kCGWindowListOptionOnScreenOnly};
 
-use super::{HitTestResult, ObstructedWindow, WindowCaptureRef};
+use super::mac_corners::{self, CgBounds};
+use super::{HitTestResult, ObstructedWindow, WindowCaptureRef, WindowTarget};
 use crate::system::MonitorInfo;
 use clowd_rust_core::geometry::{RectExt, ScreenPoint, ScreenRect};
 
@@ -24,6 +26,12 @@ const MIN_WINDOW_SIZE: i32 = 25;
 struct WindowEntry {
     window_id: u32,
     rect: ScreenRect,
+    /// `kCGWindowBounds` as reported — CG points — kept for the corner probe,
+    /// which photographs the window in that space.
+    cg_bounds: CgBounds,
+    /// Backing scale of the display the window was placed on (points →
+    /// physical px), for the lookup-table radius.
+    scale: f32,
     /// Window title text.
     title: String,
     obstructed: bool,
@@ -31,9 +39,17 @@ struct WindowEntry {
 }
 
 /// Snapshot of the top-level window list in Z-order. Created once at capture
-/// startup; queried per cursor-move via [`hit_test`].
+/// startup; queried per cursor-move via [`hit_test_target`].
 pub struct WindowWalker {
     windows: Vec<WindowEntry>,
+    /// Corner radius per entry, physical px, 0 = square. Seeded from the OS
+    /// lookup table at snapshot, then overwritten by [`probe_corner_radii`]
+    /// as the window server answers — behind a mutex because the walker is
+    /// already shared (`Arc`) with the main thread by then. All zero when
+    /// the walker was built with rounded corners off.
+    corner_radii: Mutex<Vec<f32>>,
+    /// Whether the corner probe should run at all.
+    rounded_corners: bool,
 }
 
 impl WindowWalker {
@@ -41,7 +57,7 @@ impl WindowWalker {
     ///
     /// Call once at capture startup — after the desktop bitmap is grabbed but
     /// before overlay windows are created, so our own windows are excluded.
-    pub fn snapshot(monitors: &[MonitorInfo], visibility_threshold: f32) -> Self {
+    pub fn snapshot(monitors: &[MonitorInfo], visibility_threshold: f32, rounded_corners: bool) -> Self {
         let options = kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements;
         let window_list = match window::copy_window_info(options, kCGNullWindowID) {
             Some(list) => list,
@@ -49,6 +65,8 @@ impl WindowWalker {
                 warn!("CGWindowListCopyWindowInfo returned null");
                 return WindowWalker {
                     windows: Vec::new(),
+                    corner_radii: Mutex::new(Vec::new()),
+                    rounded_corners,
                 };
             }
         };
@@ -64,20 +82,76 @@ impl WindowWalker {
         }
 
         info!("WindowWalker: captured {} top-level windows", windows.len());
+        // Seed every entry with the lookup-table radius for this OS; the
+        // probe replaces these one by one once the snapshot is published.
+        let fallback_pts = if rounded_corners {
+            mac_corners::fallback_radius_points()
+        } else {
+            0.0
+        };
+        let corner_radii = windows
+            .iter()
+            .map(|w| fallback_pts * w.scale)
+            .collect();
         WindowWalker {
             windows,
+            corner_radii: Mutex::new(corner_radii),
+            rounded_corners,
         }
     }
 
+    /// Ask the window server for each window's real corner radius and
+    /// replace the lookup-table seed with it. Front-to-back, so the windows
+    /// the user is most likely aiming at settle first. Run on the walker
+    /// thread AFTER the snapshot has been published: it is a ~10 ms
+    /// round-trip per window, and hover hit-testing must not wait on it.
+    pub fn probe_corner_radii(&self, monitors: &[MonitorInfo]) {
+        if !self.rounded_corners {
+            return;
+        }
+        let mut probed = 0usize;
+        for (i, w) in self.windows.iter().enumerate() {
+            let Some(r) = mac_corners::probe_corner_radius(w.window_id, w.cg_bounds, monitors) else {
+                continue;
+            };
+            debug!(
+                "WindowWalker: window {i} {:?} corner radius {r:.1} px (seed {:.1})",
+                w.title,
+                self.corner_radius(i)
+            );
+            if let Ok(mut radii) = self.corner_radii.lock() {
+                if let Some(slot) = radii.get_mut(i) {
+                    *slot = r;
+                    probed += 1;
+                }
+            }
+        }
+        info!("WindowWalker: measured corner radius of {probed}/{} windows", self.windows.len());
+    }
+
+    fn corner_radius(&self, index: usize) -> f32 {
+        self.corner_radii
+            .lock()
+            .ok()
+            .and_then(|r| r.get(index).copied())
+            .unwrap_or(0.0)
+    }
+
     /// Given a cursor position in virtual-desktop physical pixels, return the
-    /// suggested capture rectangle — the topmost window under the cursor.
+    /// suggested capture target — the topmost window under the cursor, with
+    /// the corner radius to draw and crop it with.
     ///
     /// Returns `None` if the cursor is over the desktop background.
-    pub fn hit_test(&self, point: ScreenPoint) -> Option<ScreenRect> {
-        self.windows
+    pub fn hit_test_target(&self, point: ScreenPoint) -> Option<WindowTarget> {
+        let (idx, w) = self
+            .windows
             .iter()
-            .find(|w| w.rect.contains(point))
-            .map(|w| w.rect)
+            .enumerate()
+            .find(|(_, w)| w.rect.contains(point))?;
+        Some(WindowTarget {
+            rect: w.rect,
+            corner_radius: self.corner_radius(idx),
+        })
     }
 
     /// The scrolling-capture target under `point`: the topmost enumerated
@@ -149,8 +223,12 @@ impl WindowWalker {
     /// taken as the topmost enumerated window (CGWindowList is front-to-back
     /// Z-order). `None` if no windows were captured, so the caller falls back
     /// to the active screen.
-    pub fn foreground_capture_rect(&self) -> Option<ScreenRect> {
-        self.windows.first().map(|w| w.rect)
+    pub fn foreground_capture_target(&self) -> Option<WindowTarget> {
+        let w = self.windows.first()?;
+        Some(WindowTarget {
+            rect: w.rect,
+            corner_radius: self.corner_radius(0),
+        })
     }
 }
 
@@ -188,7 +266,7 @@ fn evaluate_window(
     let center_x = cg_rect.origin.x + cg_rect.size.width / 2.0;
     let center_y = cg_rect.origin.y + cg_rect.size.height / 2.0;
 
-    let (phys_x, phys_y, phys_w, phys_h) = if let Some(m) = find_monitor_for_cg_point(center_x, center_y, monitors) {
+    let (phys_x, phys_y, phys_w, phys_h, scale) = if let Some(m) = find_monitor_for_cg_point(center_x, center_y, monitors) {
         let ox = m.logical_origin.x;
         let oy = m.logical_origin.y;
         let s = m.scale_factor as f64;
@@ -197,14 +275,17 @@ fn evaluate_window(
             m.bounds.min_y() + ((cg_rect.origin.y - oy) * s).round() as i32,
             (cg_rect.size.width * s).round() as i32,
             (cg_rect.size.height * s).round() as i32,
+            m.scale_factor,
         )
     } else {
-        let scale = display_scale_at_logical_point(center_x, center_y) as f64;
+        let scale = display_scale_at_logical_point(center_x, center_y);
+        let s = scale as f64;
         (
-            (cg_rect.origin.x * scale).round() as i32,
-            (cg_rect.origin.y * scale).round() as i32,
-            (cg_rect.size.width * scale).round() as i32,
-            (cg_rect.size.height * scale).round() as i32,
+            (cg_rect.origin.x * s).round() as i32,
+            (cg_rect.origin.y * s).round() as i32,
+            (cg_rect.size.width * s).round() as i32,
+            (cg_rect.size.height * s).round() as i32,
+            scale,
         )
     };
 
@@ -249,6 +330,13 @@ fn evaluate_window(
     Some(WindowEntry {
         window_id,
         rect,
+        cg_bounds: CgBounds {
+            x: cg_rect.origin.x,
+            y: cg_rect.origin.y,
+            w: cg_rect.size.width,
+            h: cg_rect.size.height,
+        },
+        scale,
         title,
         obstructed,
         obstruction_rects,

--- a/clowd_capture/src/system/mod.rs
+++ b/clowd_capture/src/system/mod.rs
@@ -1,5 +1,10 @@
+pub(crate) mod corners;
+
 #[cfg(windows)]
 mod win_browser;
+
+#[cfg(windows)]
+mod win_corners;
 
 #[cfg(windows)]
 pub(crate) mod win_capture;
@@ -26,6 +31,9 @@ pub use win_walker::WindowWalker;
 mod mac_browser;
 
 #[cfg(target_os = "macos")]
+mod mac_corners;
+
+#[cfg(target_os = "macos")]
 pub(crate) mod mac_capture;
 
 #[cfg(target_os = "macos")]
@@ -43,6 +51,18 @@ mod mac_walker;
 #[cfg(target_os = "macos")]
 use clowd_rust_core::geometry::{LogicalPoint, LogicalSize};
 use clowd_rust_core::geometry::{RectExt, ScreenPoint, ScreenPointF, ScreenRect, WindowPoint};
+
+/// What the walker suggests capturing for a point: the rect, plus the
+/// corner radius (physical px, 0 = square) the OS composites that window
+/// with. The radius is non-zero only when `rect` IS a top-level window's
+/// own bounds — a child-window region on Windows has square corners
+/// however round its parent is — and only when the walker was told to
+/// look (`rounded_corners` in [`WindowWalker::snapshot`]).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct WindowTarget {
+    pub rect: ScreenRect,
+    pub corner_radius: f32,
+}
 
 /// Full hit-test result including peek metadata.
 #[derive(Debug, Clone)]
@@ -374,8 +394,10 @@ impl SystemInterop {
     /// before overlay windows are created.
     /// `visibility_threshold`: minimum visible fraction (0.0–1.0) for a
     /// window to be included. Windows with less visible area are dropped.
-    pub fn snapshot_windows(monitors: &[MonitorInfo], visibility_threshold: f32) -> WindowWalker {
-        WindowWalker::snapshot(monitors, visibility_threshold)
+    /// `rounded_corners`: whether to resolve each window's corner radius
+    /// (see [`WindowTarget`]); off = every target is square.
+    pub fn snapshot_windows(monitors: &[MonitorInfo], visibility_threshold: f32, rounded_corners: bool) -> WindowWalker {
+        WindowWalker::snapshot(monitors, visibility_threshold, rounded_corners)
     }
 
     pub fn capture_peek_image(window: &ObstructedWindow) -> Option<(Vec<u8>, u32, u32)> {
@@ -462,8 +484,8 @@ impl SystemInterop {
         mac_monitor::all_monitors().expect("Unable to enumerate monitors")
     }
 
-    pub fn snapshot_windows(monitors: &[MonitorInfo], visibility_threshold: f32) -> WindowWalker {
-        WindowWalker::snapshot(monitors, visibility_threshold)
+    pub fn snapshot_windows(monitors: &[MonitorInfo], visibility_threshold: f32, rounded_corners: bool) -> WindowWalker {
+        WindowWalker::snapshot(monitors, visibility_threshold, rounded_corners)
     }
 
     pub fn capture_peek_image(window: &ObstructedWindow) -> Option<(Vec<u8>, u32, u32)> {

--- a/clowd_capture/src/system/win_corners.rs
+++ b/clowd_capture/src/system/win_corners.rs
@@ -1,0 +1,124 @@
+//! Win32 glue for [`super::corners`]: asks DWM and user32 what the
+//! capturer cannot decide for itself, then hands the answers to the
+//! platform-neutral policy.
+//!
+//! The policy itself (Windows 10 never rounds; 11 rounds framed top-level
+//! windows at 8 px unless maximized / snapped / remote / regioned / opted
+//! out) lives in `corners.rs` where it is unit-tested on every host. This
+//! file only gathers inputs and scales the result to the window's DPI.
+
+use std::sync::OnceLock;
+
+use windows::core::BOOL;
+use windows::Win32::Foundation::HWND;
+use windows::Win32::Graphics::Dwm::{
+    DwmGetWindowAttribute, DWMWA_WINDOW_CORNER_PREFERENCE, DWMWCP_DEFAULT, DWMWCP_DONOTROUND, DWMWCP_ROUND, DWMWCP_ROUNDSMALL,
+    DWM_WINDOW_CORNER_PREFERENCE,
+};
+use windows::Win32::Graphics::Gdi::{CreateRectRgn, DeleteObject, GetWindowRgn, RGN_ERROR};
+use windows::Win32::System::SystemInformation::{GetVersionExW, OSVERSIONINFOW};
+use windows::Win32::UI::HiDpi::GetDpiForWindow;
+use windows::Win32::UI::WindowsAndMessaging::{GetSystemMetrics, IsZoomed, SM_REMOTESESSION, WS_CAPTION, WS_THICKFRAME};
+
+use super::corners::{windows_corner_radius_logical, CornerPreference, WindowsCornerInputs};
+
+// `IsWindowArranged` (Windows 10 2004+) is exported by user32.dll without an
+// import library, so it is bound here by name rather than through the
+// `windows` crate — whose metadata may or may not carry it in the pinned
+// version — which keeps the build independent of that question.
+#[link(name = "user32.dll", kind = "raw-dylib")]
+extern "system" {
+    /// Whether the window is snapped (arranged by Snap / Snap Layouts) —
+    /// DWM does not round arranged windows, same as maximized ones.
+    fn IsWindowArranged(hwnd: HWND) -> BOOL;
+}
+
+/// `dwBuildNumber` of the running OS, read once. The shared app manifest
+/// declares Windows 10 support, so `GetVersionExW` reports the real
+/// version instead of the 6.2 compatibility lie — which is what makes it
+/// usable here without pulling in `RtlGetVersion`.
+fn os_build() -> u32 {
+    static BUILD: OnceLock<u32> = OnceLock::new();
+    *BUILD.get_or_init(|| {
+        let mut info = OSVERSIONINFOW {
+            dwOSVersionInfoSize: std::mem::size_of::<OSVERSIONINFOW>() as u32,
+            ..Default::default()
+        };
+        // Tolerant of either `BOOL` or `Result` return shapes: a failure
+        // leaves `dwBuildNumber` at 0, which the policy reads as "older
+        // than Windows 11" — square corners, the safe direction.
+        #[allow(deprecated)]
+        let _ = unsafe { GetVersionExW(&mut info) };
+        info.dwBuildNumber
+    })
+}
+
+/// Whether this is a remote (RDP / VM-redirected) session, read once.
+fn remote_session() -> bool {
+    static REMOTE: OnceLock<bool> = OnceLock::new();
+    *REMOTE.get_or_init(|| unsafe { GetSystemMetrics(SM_REMOTESESSION) != 0 })
+}
+
+/// `DWMWA_WINDOW_CORNER_PREFERENCE` for `hwnd`, or `None` if DWM would not
+/// say (older DWM, or a window it has no record of).
+fn corner_preference(hwnd: HWND) -> Option<CornerPreference> {
+    let mut pref = DWMWCP_DEFAULT;
+    let hr = unsafe {
+        DwmGetWindowAttribute(
+            hwnd,
+            DWMWA_WINDOW_CORNER_PREFERENCE,
+            &mut pref as *mut DWM_WINDOW_CORNER_PREFERENCE as *mut _,
+            std::mem::size_of::<DWM_WINDOW_CORNER_PREFERENCE>() as u32,
+        )
+    };
+    if hr.is_err() {
+        return None;
+    }
+    Some(match pref {
+        DWMWCP_DONOTROUND => CornerPreference::DoNotRound,
+        DWMWCP_ROUND => CornerPreference::Round,
+        DWMWCP_ROUNDSMALL => CornerPreference::RoundSmall,
+        _ => CornerPreference::Default,
+    })
+}
+
+/// Whether the window has a `SetWindowRgn` shape. `GetWindowRgn` returns
+/// `ERROR` for a window without one, which is the common case.
+fn has_window_region(hwnd: HWND) -> bool {
+    unsafe {
+        let rgn = CreateRectRgn(0, 0, 0, 0);
+        if rgn.is_invalid() {
+            return false;
+        }
+        let kind = GetWindowRgn(hwnd, rgn);
+        let _ = DeleteObject(rgn.into());
+        kind != RGN_ERROR
+    }
+}
+
+/// Corner radius in physical pixels DWM composites this top-level window
+/// with — 0 for square. `style` is the window's `GWL_STYLE`, already read
+/// by the walker.
+pub fn window_corner_radius(hwnd: HWND, style: u32) -> f32 {
+    let build = os_build();
+    // Everything below is Windows 11 only; skip the per-window calls on 10.
+    if build < super::corners::WINDOWS_11_FIRST_BUILD {
+        return 0.0;
+    }
+    let has_frame = (style & WS_CAPTION.0) == WS_CAPTION.0 || (style & WS_THICKFRAME.0) != 0;
+    let logical = windows_corner_radius_logical(WindowsCornerInputs {
+        build,
+        remote_session: remote_session(),
+        maximized: unsafe { IsZoomed(hwnd).as_bool() },
+        arranged: unsafe { IsWindowArranged(hwnd).as_bool() },
+        preference: corner_preference(hwnd),
+        has_region: has_window_region(hwnd),
+        has_frame,
+    });
+    if logical <= 0.0 {
+        return 0.0;
+    }
+    let dpi = unsafe { GetDpiForWindow(hwnd) };
+    let dpi = if dpi == 0 { 96 } else { dpi };
+    logical * dpi as f32 / 96.0
+}

--- a/clowd_capture/src/system/win_walker.rs
+++ b/clowd_capture/src/system/win_walker.rs
@@ -27,7 +27,7 @@ use windows::{
     },
 };
 
-use super::{HitTestResult, ObstructedWindow, WindowCaptureRef};
+use super::{HitTestResult, MonitorInfo, ObstructedWindow, WindowCaptureRef, WindowTarget};
 use clowd_rust_core::geometry::{RectExt, ScreenPoint, ScreenRect};
 
 /// Minimum top-level window dimension (px) to be considered capturable.
@@ -85,6 +85,10 @@ struct WindowEntry {
     obstructed: bool,
     /// Regions of this window covered by higher-Z windows, in virtual-desktop coords.
     obstruction_rects: Vec<ScreenRect>,
+    /// Corner radius DWM composites this window with, in physical px
+    /// (0 = square; always 0 when the walker was built with rounded
+    /// corners off). See `win_corners`.
+    corner_radius: f32,
 }
 
 // ---------------------------------------------------------------------------
@@ -92,13 +96,13 @@ struct WindowEntry {
 // ---------------------------------------------------------------------------
 
 /// Snapshot of the top-level window list in Z-order. Created once at capture
-/// startup; queried per cursor-move via [`hit_test`].
+/// startup; queried per cursor-move via [`hit_test_target`].
 pub struct WindowWalker {
     windows: Vec<WindowEntry>,
-    /// True bounds of the foreground window at snapshot time, if it survived
-    /// the enumeration filters. Used by `--capture-mode window` to pre-select
-    /// the active window (see [`foreground_capture_rect`]).
-    foreground_rect: Option<ScreenRect>,
+    /// Index into `windows` of the foreground window at snapshot time, if it
+    /// survived the enumeration filters. Used by `--capture-mode window` to
+    /// pre-select the active window (see [`foreground_capture_target`]).
+    foreground_index: Option<usize>,
 }
 
 // SAFETY: WindowWalker holds HWND values which are plain integer handles.
@@ -111,7 +115,7 @@ impl WindowWalker {
     ///
     /// Call once at capture startup — after the desktop bitmap is grabbed but
     /// before overlay windows are created, so our own windows are excluded.
-    pub fn snapshot(_monitors: &[super::MonitorInfo], visibility_threshold: f32) -> Self {
+    pub fn snapshot(_monitors: &[MonitorInfo], visibility_threshold: f32, rounded_corners: bool) -> Self {
         // Grab the foreground window first — before overlay windows exist —
         // so `--capture-mode window` can pre-select the truly active window
         // regardless of where the cursor is. Matched to an enumerated entry
@@ -148,7 +152,7 @@ impl WindowWalker {
         let mut windows: Vec<WindowEntry> = Vec::new();
 
         for hwnd in hwnds {
-            if let Some(entry) = evaluate_window(hwnd, &vdm, &windows, visibility_threshold) {
+            if let Some(entry) = evaluate_window(hwnd, &vdm, &windows, visibility_threshold, rounded_corners) {
                 windows.push(entry);
             }
         }
@@ -156,37 +160,51 @@ impl WindowWalker {
         // Resolve the foreground window to a capture rect. Only accept it if it
         // survived enumeration (a normal, on-screen app window); otherwise leave
         // it None so the caller can fall back to the active screen.
-        let foreground_rect = if foreground_hwnd.0.is_null() {
+        let foreground_index = if foreground_hwnd.0.is_null() {
             None
         } else {
             windows
                 .iter()
-                .find(|w| w.hwnd == foreground_hwnd)
-                .map(|w| w.rect)
+                .position(|w| w.hwnd == foreground_hwnd)
         };
 
         info!("WindowWalker: captured {} top-level windows", windows.len());
         WindowWalker {
             windows,
-            foreground_rect,
+            foreground_index,
         }
     }
+
+    /// Corner radii on Windows are resolved synchronously during
+    /// [`snapshot`] (a handful of user32/DWM calls per window), so there is
+    /// nothing to refine afterwards. Exists so the walker thread can call
+    /// it on both platforms; macOS does the expensive window-server probe
+    /// here.
+    pub fn probe_corner_radii(&self, _monitors: &[MonitorInfo]) {}
 
     /// Capture rect for `--capture-mode window`: the true bounds of the window
     /// that was in the foreground when the capture began, or `None` if that
     /// window is not a valid capture target (the caller should fall back to the
     /// active screen).
-    pub fn foreground_capture_rect(&self) -> Option<ScreenRect> {
-        self.foreground_rect
+    pub fn foreground_capture_target(&self) -> Option<WindowTarget> {
+        let w = self.windows.get(self.foreground_index?)?;
+        Some(WindowTarget {
+            rect: w.rect,
+            corner_radius: w.corner_radius,
+        })
     }
 
     /// Given a cursor position in virtual-desktop physical pixels, return the
-    /// suggested capture rectangle — the deepest meaningful child window
-    /// region under the cursor, clipped to the top-level window bounds.
+    /// suggested capture target — the deepest meaningful child window
+    /// region under the cursor, clipped to the top-level window bounds —
+    /// with the corner radius to draw and crop it with. The radius is the
+    /// top-level window's only when the suggested rect IS the whole window;
+    /// a child region (a browser viewport, a pane) has square corners
+    /// regardless.
     ///
     /// Returns `None` if the cursor is over the desktop background (no
     /// captured window contains the point).
-    pub fn hit_test(&self, point: ScreenPoint) -> Option<ScreenRect> {
+    pub fn hit_test_target(&self, point: ScreenPoint) -> Option<WindowTarget> {
         // Find the topmost (first in Z-order) window containing the point.
         let top = self
             .windows
@@ -259,13 +277,17 @@ impl WindowWalker {
         // Clip to the top-level window bounds.
         let clipped = ideal_rect.intersection(&top_rect)?;
         if clipped.width() > 0 && clipped.height() > 0 {
-            Some(clipped)
+            let corner_radius = if clipped == top_rect { top.corner_radius } else { 0.0 };
+            Some(WindowTarget {
+                rect: clipped,
+                corner_radius,
+            })
         } else {
             None
         }
     }
 
-    /// Handle of the top-level window [`hit_test`] would pick for `point`
+    /// Handle of the top-level window [`hit_test_target`] would pick for `point`
     /// — the first entry in Z-order whose true bounds contain it — as a
     /// plain integer, or `None` over the desktop background.
     ///
@@ -325,7 +347,7 @@ impl WindowWalker {
             .collect()
     }
 
-    /// Same as [`hit_test`] but also returns the title of the top-level window
+    /// Same as [`hit_test_target`] but also returns the title of the top-level window
     /// that contains the point.
     pub fn hit_test_with_title(&self, point: ScreenPoint) -> Option<(ScreenRect, String)> {
         // Find the topmost (first in Z-order) window containing the point.
@@ -431,6 +453,7 @@ fn evaluate_window(
     vdm: &Option<IVirtualDesktopManager>,
     accepted: &[WindowEntry],
     visibility_threshold: f32,
+    rounded_corners: bool,
 ) -> Option<WindowEntry> {
     unsafe {
         // 1. Basic visibility.
@@ -528,6 +551,14 @@ fn evaluate_window(
         let obstructed = !obstruction_rects.is_empty();
 
         let title = get_window_text(hwnd);
+        // Last, once the window is known to be a capture target: a few more
+        // user32/DWM round-trips per window, skipped entirely when the
+        // feature is off.
+        let corner_radius = if rounded_corners {
+            super::win_corners::window_corner_radius(hwnd, style)
+        } else {
+            0.0
+        };
         Some(WindowEntry {
             hwnd,
             rect,
@@ -535,6 +566,7 @@ fn evaluate_window(
             title,
             obstructed,
             obstruction_rects,
+            corner_radius,
         })
     }
 }

--- a/clowd_capture/src/ui/gpu/lift.rs
+++ b/clowd_capture/src/ui/gpu/lift.rs
@@ -28,7 +28,10 @@ use clowd_rust_core::geometry::RectExt;
 struct LiftInstance {
     /// min_x, min_y, max_x, max_y in window-local physical pixels.
     dest_px: [f32; 4],
-    /// (alpha, band_centre, sweep σ, unused).
+    /// (alpha, band_centre, sweep σ, corner radius). The radius is the
+    /// selection's, in window-local px (0 = square); the fragment clips the
+    /// band to that rounded rect so it cannot spill into the faded corners
+    /// outside a picked window's curved border.
     params: [f32; 4],
     /// Band colour (straight alpha 1.0; the fragment premultiplies).
     tint: [f32; 4],
@@ -263,7 +266,10 @@ impl LiftPipeline {
                 dest[2] - mon_f.left(),
                 dest[3] - mon_f.top(),
             ],
-            params: [SWEEP_ALPHA, band, anim::SWEEP_SIGMA, 0.0],
+            // The OCR region IS the (frozen) selection, so the selection's
+            // radius is the region's. Zoom is 1 once captured, so physical
+            // px need no scaling here.
+            params: [SWEEP_ALPHA, band, anim::SWEEP_SIGMA, state.selection_radius.max(0.0)],
             tint: [1.0, 1.0, 1.0, 1.0],
         });
 

--- a/clowd_capture/src/ui/shared.rs
+++ b/clowd_capture/src/ui/shared.rs
@@ -38,6 +38,11 @@ pub struct UiMonitor {
 pub struct UiSharedState {
     pub monitors: Arc<[UiMonitor]>,
     pub selection: Option<ScreenRect>,
+    /// Corner radius of `selection` in physical px, 0 = square — see
+    /// `InteractionState::selection_radius`. Read by overlays that paint
+    /// INSIDE the selection (the OCR sweep) so they stop at the same curve
+    /// the desktop pass draws the border around.
+    pub selection_radius: f32,
     pub captured: bool,
     pub mouse_down: bool,
     pub dragging: bool,
@@ -314,6 +319,7 @@ mod tests {
         UiSharedState {
             monitors: Arc::from([monitor()]),
             selection: Some(ScreenRect::from_xy_size(20, 20, 80, 40)),
+            selection_radius: 0.0,
             captured: false,
             mouse_down: false,
             dragging: false,

--- a/clowd_capture/src/ui_state.rs
+++ b/clowd_capture/src/ui_state.rs
@@ -11,6 +11,7 @@ pub struct UiStateBuildInput<'a> {
     /// Invariant for the whole session — build once and clone the Arc.
     pub monitors: Arc<[UiMonitor]>,
     pub selection: Option<ScreenRect>,
+    pub selection_radius: f32,
     pub captured: bool,
     pub mouse_down: bool,
     pub dragging: bool,
@@ -73,6 +74,7 @@ pub fn build_ui_shared_state(input: UiStateBuildInput<'_>) -> UiSharedState {
     UiSharedState {
         monitors: input.monitors,
         selection: input.selection,
+        selection_radius: input.selection_radius,
         captured: input.captured,
         mouse_down: input.mouse_down,
         dragging: input.dragging,

--- a/clowd_rust_core/src/session.rs
+++ b/clowd_rust_core/src/session.rs
@@ -36,6 +36,17 @@ pub struct SessionJson {
     pub cursor_position: Option<RectJson>,
     pub cropped_rect: RectJson,
     pub original_bounds: RectJson,
+    /// Corner radius, in physical pixels of `cropped_rect`, that the
+    /// capture's corners are rounded with — the OS corner radius of a
+    /// picked window (CAPTURE_PROTOCOL.md §1.3). Omitted when square
+    /// (0), which is every dragged selection and every scrolling capture,
+    /// so an older shell reading the file sees exactly what it always did.
+    #[serde(skip_serializing_if = "is_zero")]
+    pub corner_radius: f32,
+}
+
+fn is_zero(v: &f32) -> bool {
+    *v <= 0.0
 }
 
 /// Serialized shape of `Clowd.PlatformUtil.ScreenRect` (exact key
@@ -147,10 +158,36 @@ mod tests {
             cursor_position: None,
             cropped_rect: ScreenRect::from_xy_size(0, 0, 10, 10).into(),
             original_bounds: ScreenRect::from_xy_size(5, 5, 10, 10).into(),
+            corner_radius: 0.0,
         };
         let json = serde_json::to_string(&info).unwrap();
         assert!(!json.contains("CursorImgPath"));
         assert!(!json.contains("CursorPosition"));
         assert!(json.contains(r#""DesktopImgPath":"C:\\s\\desktop.png""#));
+    }
+
+    /// A square capture writes no `CornerRadius` at all — the file is
+    /// byte-identical to what it was before the key existed — and a
+    /// rounded one carries the radius in the crop's pixel units.
+    #[test]
+    fn session_json_writes_corner_radius_only_when_rounded() {
+        let mut info = SessionJson {
+            created_utc: "2026-01-01T00:00:00Z".to_string(),
+            name: "Screenshot",
+            desktop_img_path: "d.png".to_string(),
+            preview_img_path: "c.png".to_string(),
+            cursor_img_path: None,
+            cursor_position: None,
+            cropped_rect: ScreenRect::from_xy_size(0, 0, 10, 10).into(),
+            original_bounds: ScreenRect::from_xy_size(5, 5, 10, 10).into(),
+            corner_radius: 0.0,
+        };
+        assert!(!serde_json::to_string(&info)
+            .unwrap()
+            .contains("CornerRadius"));
+        info.corner_radius = 16.0;
+        assert!(serde_json::to_string(&info)
+            .unwrap()
+            .contains(r#""CornerRadius":16.0"#));
     }
 }

--- a/clowd_scroll_driver/src/output.rs
+++ b/clowd_scroll_driver/src/output.rs
@@ -50,6 +50,8 @@ pub fn write_session(session_dir: &Path, composite: Composite) -> anyhow::Result
         cursor_position: None,
         cropped_rect: ScreenRect::from_xy_size(0, 0, width as i32, height as i32).into(),
         original_bounds: ScreenRect::zero().into(),
+        // A stitched page is a rectangle of content, not a window frame.
+        corner_radius: 0.0,
     };
 
     let json_path = session_dir.join("session.json");

--- a/clowd_ui/Clowd.Drawing.Tests/GraphicImageTests.cs
+++ b/clowd_ui/Clowd.Drawing.Tests/GraphicImageTests.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using Avalonia;
 using Avalonia.Headless.XUnit;
+using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
 using Clowd.Drawing.Graphics;
@@ -97,6 +98,113 @@ namespace Clowd.Drawing.Tests
                 using var scaled = graphic.ImageSource.CreateScaledBitmap(new PixelSize(5, 4));
                 Assert.Equal(5, scaled.PixelSize.Width);
                 Assert.Equal(4, scaled.PixelSize.Height);
+            }
+            finally
+            {
+                dir.Delete(true);
+            }
+        }
+
+        // ====================================================================
+        // Corner radius: a picked window's rounded corners (seeded from session.json) and any
+        // radius the user sets afterwards are a rounded clip around the drawn crop — the corners
+        // must come out transparent in the export bitmap, the straight edges and interior must not.
+        // ====================================================================
+
+        private static (byte B, byte G, byte R, byte A) ExportPixel(Bitmap bmp, int x, int y)
+        {
+            var buffer = new byte[4];
+            var handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+            try
+            {
+                bmp.CopyPixels(new PixelRect(x, y, 1, 1), handle.AddrOfPinnedObject(), buffer.Length, 4);
+            }
+            finally
+            {
+                handle.Free();
+            }
+
+            return (buffer[0], buffer[1], buffer[2], buffer[3]);
+        }
+
+        [AvaloniaFact]
+        public void CornerRadius_ExportsTransparentCorners()
+        {
+            var dir = Directory.CreateTempSubdirectory();
+            try
+            {
+                var imgPath = Path.Combine(dir.FullName, "img.png");
+                // opaque everywhere (white/black seam at x=30 — any opaque content does)
+                WriteSeamPng(imgPath, 60, 40, 30);
+
+                var canvas = new DrawingCanvas { Tool = ToolType.None };
+                var img = new GraphicImage(imgPath, new Rect(0, 0, 60, 40), default) { CornerRadius = 12 };
+                canvas.GraphicsList.Add(img);
+
+                using var bmp = canvas.GraphicsList.DrawGraphicsToBitmap(Brushes.Transparent);
+                Assert.NotNull(bmp);
+                Assert.Equal(60, bmp.PixelSize.Width);
+                Assert.Equal(40, bmp.PixelSize.Height);
+
+                // the four corner pixels sit well outside a 12px arc → fully transparent
+                foreach (var (x, y) in new[] { (0, 0), (59, 0), (0, 39), (59, 39) })
+                    Assert.Equal(0, ExportPixel(bmp, x, y).A);
+
+                // the straight edges between the arcs, and the interior, stay opaque
+                Assert.Equal(255, ExportPixel(bmp, 30, 0).A);
+                Assert.Equal(255, ExportPixel(bmp, 0, 20).A);
+                Assert.Equal(255, ExportPixel(bmp, 59, 20).A);
+                Assert.Equal(255, ExportPixel(bmp, 30, 20).A);
+                // and the inner corner of the 12px square (inside the arc) is opaque too
+                Assert.Equal(255, ExportPixel(bmp, 11, 11).A);
+            }
+            finally
+            {
+                dir.Delete(true);
+            }
+        }
+
+        [AvaloniaFact]
+        public void CornerRadius_ZeroIsSquare()
+        {
+            var dir = Directory.CreateTempSubdirectory();
+            try
+            {
+                var imgPath = Path.Combine(dir.FullName, "img.png");
+                WriteSeamPng(imgPath, 20, 16, 10);
+
+                var canvas = new DrawingCanvas { Tool = ToolType.None };
+                canvas.GraphicsList.Add(new GraphicImage(imgPath, new Rect(0, 0, 20, 16), default));
+
+                using var bmp = canvas.GraphicsList.DrawGraphicsToBitmap(Brushes.Transparent);
+                foreach (var (x, y) in new[] { (0, 0), (19, 0), (0, 15), (19, 15) })
+                    Assert.Equal(255, ExportPixel(bmp, x, y).A);
+            }
+            finally
+            {
+                dir.Delete(true);
+            }
+        }
+
+        [AvaloniaFact]
+        public void CornerRadius_ScalesWithTheDrawnSize()
+        {
+            // the radius is in bitmap pixels: drawn at 2× the crop, a 4px radius rounds an 8px
+            // corner, so the pixel at (5,5) — inside a 4px arc, outside an 8px one — is cut
+            var dir = Directory.CreateTempSubdirectory();
+            try
+            {
+                var imgPath = Path.Combine(dir.FullName, "img.png");
+                WriteSeamPng(imgPath, 20, 20, 10);
+
+                var canvas = new DrawingCanvas { Tool = ToolType.None };
+                canvas.GraphicsList.Add(new GraphicImage(imgPath, new Rect(0, 0, 40, 40), default) { CornerRadius = 4 });
+
+                using var bmp = canvas.GraphicsList.DrawGraphicsToBitmap(Brushes.Transparent);
+                Assert.Equal(40, bmp.PixelSize.Width);
+                Assert.Equal(0, ExportPixel(bmp, 0, 0).A);
+                Assert.True(ExportPixel(bmp, 1, 1).A < 255, "an 8px arc leaves (1,1) outside");
+                Assert.Equal(255, ExportPixel(bmp, 8, 8).A);
             }
             finally
             {

--- a/clowd_ui/Clowd.Drawing/Graphics/GraphicImage.cs
+++ b/clowd_ui/Clowd.Drawing/Graphics/GraphicImage.cs
@@ -11,7 +11,7 @@ using Clowd.Drawing.Rendering;
 
 namespace Clowd.Drawing.Graphics
 {
-    [GraphicDesc("Image", Skills = Skill.Angle | Skill.Crop | Skill.Cursor)]
+    [GraphicDesc("Image", Skills = Skill.Angle | Skill.Crop | Skill.Cursor | Skill.Radius)]
     public class GraphicImage : GraphicRectangle
     {
         public bool Editing => !_editingAnchor.IsEmptyRect();
@@ -94,6 +94,31 @@ namespace Clowd.Drawing.Graphics
         {
             get => _crop;
             set => Set(ref _crop, value);
+        }
+
+        /// <summary>
+        /// For an image the inherited <see cref="GraphicRectangle.CornerRadius"/> is read in
+        /// <b>bitmap (crop) pixels</b>, not canvas units: it is seeded from the capturer's
+        /// <c>CornerRadius</c> (the OS corner radius of the picked window, in pixels of the crop —
+        /// CAPTURE_PROTOCOL.md §1.3), and a corner radius that is a property of the photographed
+        /// window should keep rounding the same pixels however the graphic is stretched on the
+        /// canvas. At draw time it is scaled by the render scale (drawn width ÷ crop width) and
+        /// clamped like a rectangle's, then applied as a rounded clip around the drawn crop, so the
+        /// corners are transparent on screen and in every export. The properties bar edits it
+        /// through the same "Radius" spinner rectangles use; at the 1:1 scale a capture opens at
+        /// the number shown is exactly the pixels being cut.
+        /// </summary>
+        /// <remarks>Returns the clip radius in canvas units for <paramref name="drawn"/>, or 0 when
+        /// there is nothing to round.</remarks>
+        internal double DrawnCornerRadius(Rect drawn, Rect crop)
+        {
+            if (CornerRadius <= 0 || crop.Width <= 0 || drawn.Width <= 0)
+                return 0;
+            // the horizontal scale is the one the width-based radius travels with; the crop's
+            // aspect is preserved on load and a user stretch changes both axes the same way in
+            // the common (corner-handle) case — the clamp below covers the rest
+            var scaled = CornerRadius * (drawn.Width / crop.Width);
+            return Math.Max(0, Math.Min(scaled, Math.Min(drawn.Width, drawn.Height) / 2));
         }
 
         public int FlipX
@@ -268,6 +293,26 @@ namespace Clowd.Drawing.Graphics
             // decision #21: CroppedBitmap → DrawImage with the crop as the source rect.
             Rect r = UnrotatedBounds;
             Rect src = Crop.IsEmptyRect() ? new Rect(_imageSource.Size) : Crop.ToRect();
+
+            // A rounded image (a picked window's corner radius, or one the user set) is the same
+            // blit under a rounded clip — the corners stay transparent rather than showing the
+            // pixels that sat behind the window, on screen and in DrawObject's export alike. The
+            // clip is pushed inside the rotate/flip transforms the body runs under, so it follows
+            // them for free. No clip at all for 0: the plain path stays byte-identical.
+            var radius = DrawnCornerRadius(r, src);
+            if (radius > 0)
+            {
+                using (ctx.PushClip(new RoundedRect(r, radius)))
+                    DrawImagePixels(ctx, src, r);
+            }
+            else
+            {
+                DrawImagePixels(ctx, src, r);
+            }
+        }
+
+        private void DrawImagePixels(DrawingContext ctx, Rect src, Rect r)
+        {
             ctx.DrawImage(_imageSource, src, r);
             if (_imageObscured != null || UpdateObscureCache())
             {

--- a/clowd_ui/Clowd.Shared.Tests/SettingsRoundTripTests.cs
+++ b/clowd_ui/Clowd.Shared.Tests/SettingsRoundTripTests.cs
@@ -40,6 +40,7 @@ namespace Clowd.Shared.Tests
             Assert.Equal(new SimpleKeyGesture(Key.Snapshot), loaded.Hotkeys.CaptureRegionShortcut);
             Assert.Equal(Colors.Transparent, loaded.Editor.CanvasBackground);
             Assert.Equal(0.80, loaded.Capture.ObscuredWindowDetectionThreshold);
+            Assert.True(loaded.Capture.RoundedWindowCorners);
             Assert.Empty(loaded.Editor.Tools);
         }
 
@@ -52,6 +53,7 @@ namespace Clowd.Shared.Tests
             original.General.LastSavePath = @"C:\Users\test\Pictures";
             original.General.ConfirmClose = false;
             original.Capture.ScreenshotWithCursor = false;
+            original.Capture.RoundedWindowCorners = false;
             original.Capture.TipsMode = CapturerTipsMode.Off; // enum by name (non-default)
             original.Capture.ObscuredWindowDetectionThreshold = 0.55; // invariant double
             original.Editor.StartupPadding = 42;
@@ -90,6 +92,7 @@ namespace Clowd.Shared.Tests
             Assert.Equal(@"C:\Users\test\Pictures", loaded.General.LastSavePath);
             Assert.False(loaded.General.ConfirmClose);
             Assert.False(loaded.Capture.ScreenshotWithCursor);
+            Assert.False(loaded.Capture.RoundedWindowCorners);
             Assert.Equal(CapturerTipsMode.Off, loaded.Capture.TipsMode);
             Assert.Equal(0.55, loaded.Capture.ObscuredWindowDetectionThreshold);
             Assert.Equal(42, loaded.Editor.StartupPadding);

--- a/clowd_ui/Clowd.Shared/Config/SettingsCapture.cs
+++ b/clowd_ui/Clowd.Shared/Config/SettingsCapture.cs
@@ -109,6 +109,25 @@ namespace Clowd.Config
             set => Set(ref _tipsMode, value);
         }
 
+        /// <summary>
+        /// Whether a selection made by picking a window (hover and click, <c>W</c>, the
+        /// capture-window hotkey) takes on that window's OS corner radius — rounded dashed
+        /// border in the overlay, transparent corners in the copied / saved / uploaded image
+        /// — instead of a sharp rectangle that ships a few pixels of whatever sat behind the
+        /// window. Dragged selections stay square either way (clowd_capture
+        /// <c>--no-rounded-corners</c>). On by default: it is what the screen actually shows.
+        /// </summary>
+        [Category("Behavior")]
+        [DisplayName("Rounded window corners")]
+        [Description("When a window is selected, match its rounded corners: the selection border " +
+                     "follows the window's corner radius and the corners are transparent in the " +
+                     "copied or saved image. Dragged selections are always square.")]
+        public bool RoundedWindowCorners
+        {
+            get => _roundedWindowCorners;
+            set => Set(ref _roundedWindowCorners, value);
+        }
+
         [Category("Behavior")]
         [DisplayName("Obscured window peek")]
         [Description("Capture obstructed windows and show a peek-through composite when hovering them")]
@@ -193,6 +212,7 @@ namespace Clowd.Config
         private bool _detectWindows = true;
         private CapturerTipsMode _tipsMode = CapturerTipsMode.Hints;
         private bool _obscuredWindowPeek = true;
+        private bool _roundedWindowCorners = true;
         private bool _uploadButtonEnabled = true;
         private bool _scrollingCaptureEnabled = true;
         private bool _scrollCaptureRewindToTop = true;

--- a/clowd_ui/Clowd.Ui/Editor/EditorWindow.axaml
+++ b/clowd_ui/Clowd.Ui/Editor/EditorWindow.axaml
@@ -224,7 +224,10 @@
 
             <StackPanel IsVisible="{Binding ElementName=drawingCanvas, Path=SubjectSkill, Mode=OneWay, Converter={StaticResource enumMatch}, ConverterParameter=Radius}">
                 <TextBlock VerticalAlignment="Center" Text="Radius:" />
+                <!-- 4px wider than the theme's 70: a window's corner radius runs to two digits
+                     plus the "px" suffix, which sits tight at the default width. -->
                 <controls:SpinnerTextBox
+                    Width="74"
                     Min="0"
                     SnapToWholeNumber="True"
                     SpinAmount="1"

--- a/clowd_ui/Clowd.Ui/Editor/EditorWindow.axaml
+++ b/clowd_ui/Clowd.Ui/Editor/EditorWindow.axaml
@@ -224,10 +224,10 @@
 
             <StackPanel IsVisible="{Binding ElementName=drawingCanvas, Path=SubjectSkill, Mode=OneWay, Converter={StaticResource enumMatch}, ConverterParameter=Radius}">
                 <TextBlock VerticalAlignment="Center" Text="Radius:" />
-                <!-- 4px wider than the theme's 70: a window's corner radius runs to two digits
+                <!-- 12px wider than the theme's 70: a window's corner radius runs to two digits
                      plus the "px" suffix, which sits tight at the default width. -->
                 <controls:SpinnerTextBox
-                    Width="74"
+                    Width="82"
                     Min="0"
                     SnapToWholeNumber="True"
                     SpinAmount="1"

--- a/clowd_ui/Clowd.Ui/Editor/EditorWindow.axaml.cs
+++ b/clowd_ui/Clowd.Ui/Editor/EditorWindow.axaml.cs
@@ -970,6 +970,12 @@ namespace Clowd.UI
                     cursorPosition: cursor,
                     cursorVisible: _settings.Capture.ScreenshotWithCursor);
 
+                // a picked window's rounded corners: desktop.png is a plain bitmap, so the radius the
+                // capturer measured travels in session.json and the graphic rounds the crop itself
+                // (bitmap px — the graphic opens at 1:1, and the user can change it in the bar)
+                if (_session.CornerRadius > 0)
+                    graphic.CornerRadius = _session.CornerRadius;
+
                 // add image
                 drawingCanvas.AddGraphic(graphic);
             }

--- a/clowd_ui/Clowd.Ui/Services/ScreenCaptureService.cs
+++ b/clowd_ui/Clowd.Ui/Services/ScreenCaptureService.cs
@@ -459,6 +459,9 @@ namespace Clowd.UI
             if (!settings.ScreenshotWithCursor)
                 args.Add("--no-cursor");
 
+            if (!settings.RoundedWindowCorners)
+                args.Add("--no-rounded-corners");
+
             // The overlay's optional buttons (SettingsCapture "Optional features"). All on by
             // default, so these only ever appear when the user has switched something off.
             if (!settings.UploadButtonEnabled)

--- a/clowd_ui/Clowd.Ui/Session/SessionInfo.cs
+++ b/clowd_ui/Clowd.Ui/Session/SessionInfo.cs
@@ -85,6 +85,17 @@ namespace Clowd
             set => Set(value);
         }
 
+        // corner radius (in pixels of CroppedRect) the capture's corners are rounded with — the OS
+        // corner radius of the window the user picked in the capturer. 0 / absent = square, which
+        // is every dragged selection, every scrolling capture and every session written before the
+        // key existed (CAPTURE_PROTOCOL.md §1.3). The editor seeds its image graphic's CornerRadius
+        // from it; after that the graphic's own (user-editable) value is the one that matters.
+        public double CornerRadius
+        {
+            get => Get<double>();
+            set => Set(value);
+        }
+
         public SessionOpenEditor OpenEditor
         {
             get => Get<SessionOpenEditor>();


### PR DESCRIPTION
## Summary
- Picking a window in the capturer (hover + click, `W`, `--capture-mode window`) gives the selection that window's OS corner radius: rounded AA dashed border in the overlay, transparent corners in COPY / SAVE / `cropped.png`. Dragged, moved or resized selections stay square.
- Radius source: OS first, per-version table as fallback (unknown newer OS → square).
  - macOS: table seed (11–15: 10pt, 26: 16pt), then per-window measurement from the window server's own corner mask (tiny `CGWindowListCreateImage` corner probe) on the walker thread after the snapshot is published — toolbar / titlebar-only / custom windows each get their real value.
  - Windows 11: `DWMWA_WINDOW_CORNER_PREFERENCE` when DWM answers, else the documented rounding policy (framed top-level, not maximized/snapped/remote/regioned → 8px), DPI-scaled; only when the hit rect is the top-level window. Win10 → square.
- Marching-ants period snaps to the border perimeter (square or rounded) so the pattern wraps seamlessly; nominal mid-drag so dashes don't breathe under the cursor.
- Editor: `session.json` gains optional `CornerRadius`; `GraphicImage` clips its crop to it (transparent in exports) and the existing "Radius" spinner edits it.
- Opt-out: `--no-rounded-corners` / Clowd.Ui **Behavior → Rounded window corners** (default on). `CAPTURE_PROTOCOL.md` updated.

## Test plan
- [x] `cargo fmt --check`, clippy `-D warnings` (core, capture, scroll driver), tests: core 8, capture 153, scroll driver 41 (macOS)
- [x] `dotnet build` Clowd.Ui; Clowd.Drawing.Tests 120/120, Clowd.Shared.Tests 163/163
- [x] Shaders validated with naga; live `--bench-startup` run on macOS 26 shows the corner probe measuring real radii
- [ ] Windows CI build of the new `win_corners.rs` (not compilable locally on macOS)
- [ ] Manual: pick a window on Win11 / macOS, check border + copied PNG corners; drag a selection stays square; toggle the setting off